### PR TITLE
:sparkles: Add same item decoration in fuzzy-finder as in tree-view

### DIFF
--- a/lib/fuzzy-finder-view.coffee
+++ b/lib/fuzzy-finder-view.coffee
@@ -54,7 +54,9 @@ class FuzzyFinderView extends SelectListView
         else
           typeClass = 'icon-file-text'
 
-        @div path.basename(filePath), class: "primary-line file icon #{typeClass}"
+        fileBasename = path.basename(filePath)
+
+        @div fileBasename, class: "primary-line file icon #{typeClass}", 'data-name': fileBasename, 'data-path': projectRelativePath
         @div projectRelativePath, class: 'secondary-line path no-icon'
 
   openPath: (filePath, lineNumber) ->

--- a/spec/fuzzy-finder-spec.coffee
+++ b/spec/fuzzy-finder-spec.coffee
@@ -72,7 +72,13 @@ describe 'FuzzyFinder', ->
             expect(projectView.list.children('li').length).toBe paths.length
             for filePath in paths
               expect(projectView.list.find("li:contains(#{path.basename(filePath)})")).toExist()
-            expect(projectView.list.children().first()).toHaveClass 'selected'
+            firstChild = projectView.list.children().first()
+            firstChildName = firstChild.find('div:first-child')
+            firstChildPath = firstChild.find('div:last-child')
+
+            expect(firstChild).toHaveClass 'selected'
+            expect(firstChildName).toHaveAttr('data-name', firstChildName.text())
+            expect(firstChildName).toHaveAttr('data-path', firstChildPath.text())
             expect(projectView.find(".loading")).not.toBeVisible()
 
         it "only creates a single path loader task", ->


### PR DESCRIPTION
By adding the same data-attributes in the fuzzy-finder items as in
tree-view items the same css can apply immediately.

![Screenshot](http://i.imgur.com/e7ugyiK.png)
