### PR TITLE
Move exact file name matches to the top of the SelectItemView list

### DIFF
--- a/lib/fuzzy-finder-view.coffee
+++ b/lib/fuzzy-finder-view.coffee
@@ -114,6 +114,17 @@ class FuzzyFinderView extends SelectListView
   setItems: (filePaths) ->
     super(@projectRelativePathsForFilePaths(filePaths))
 
+  # Public: Populate the list view with the model items previously set by
+  # calling {::setItems}
+  # After populate it moves exact string matches to top
+  populateList: ->
+    super()
+    query = @getFilterQuery()
+    for line in @list.find('li .primary-line')
+      if line.innerHTML is query
+        @list.prepend(line.parentElement)
+        @selectItemView(@list.find('li:first'))
+
   projectRelativePathsForFilePaths: (filePaths) ->
     # Don't regenerate project relative paths unless the file paths have changed
     if filePaths isnt @filePaths


### PR DESCRIPTION
I got a bit annoyed at having exact file name matches below other matches. So this moves exact matches to the top. If file name match is not exact, this code does no other modifications.

Probably the real fix should take place in the scoring class. I have no idea why the scoring scores exact matches below other matches, but it does
