### PR TITLE
Allow fuzzy finding for Rails namespaced classes

### DIFF
--- a/lib/fuzzy-finder-view.coffee
+++ b/lib/fuzzy-finder-view.coffee
@@ -97,6 +97,7 @@ class FuzzyFinderView extends SelectListView
 
   getFilterQuery: ->
     query = super
+    query = query.replace(/::/g, "/")
     colon = query.indexOf(':')
     if colon is -1
       query


### PR DESCRIPTION
I'd like to be able to paste in to the Fuzzy Finder something like "My::Namespaced::Class" and have it suggest "my/namespaced/class.rb" in the list of suggestions.  The code below works, but I couldn't figure out how to write a coffeescript spec for it (I was able to run the specs, I had a spec I thought may work as a basis copied, but could't figure it out from there - I'm no JS/Atom developer).

If this direct change isn't acceptable, any suggestions on how we could make it a configurable option - "combinations of characters to treat as directory separator" or something?

Any comments, tips?  Thanks.
