### PR TITLE
Use core.followSymlinks rather than the fuzzy-finder specific option

### DIFF
--- a/lib/load-paths-handler.coffee
+++ b/lib/load-paths-handler.coffee
@@ -73,7 +73,7 @@ class PathLoader
         done
       )
 
-module.exports = (rootPaths, traverseIntoSymlinkDirectories, ignoreVcsIgnores, ignores=[]) ->
+module.exports = (rootPaths, followSymlinks, ignoreVcsIgnores, ignores=[]) ->
   ignoredNames = []
   for ignore in ignores when ignore
     try
@@ -87,7 +87,7 @@ module.exports = (rootPaths, traverseIntoSymlinkDirectories, ignoreVcsIgnores, i
       new PathLoader(
         rootPath,
         ignoreVcsIgnores,
-        traverseIntoSymlinkDirectories,
+        followSymlinks,
         ignoredNames
       ).load(next)
     @async()

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -3,9 +3,6 @@ module.exports =
     ignoredNames:
       type: 'array'
       default: []
-    traverseIntoSymlinkDirectories:
-      type: 'boolean'
-      default: false
 
   activate: (state) ->
     atom.commands.add 'atom-workspace',

--- a/lib/path-loader.coffee
+++ b/lib/path-loader.coffee
@@ -4,7 +4,7 @@ module.exports =
   startTask: (callback) ->
     projectPaths = []
     taskPath = require.resolve('./load-paths-handler')
-    traverseIntoSymlinkDirectories = atom.config.get 'fuzzy-finder.traverseIntoSymlinkDirectories'
+    followSymlinks = atom.config.get 'core.followSymlinks'
     ignoredNames = atom.config.get('fuzzy-finder.ignoredNames') ? []
     ignoredNames = ignoredNames.concat(atom.config.get('core.ignoredNames') ? [])
     ignoreVcsIgnores = atom.config.get('core.excludeVcsIgnoredPaths')
@@ -12,7 +12,7 @@ module.exports =
     task = Task.once(
       taskPath,
       atom.project.getPaths(),
-      traverseIntoSymlinkDirectories,
+      followSymlinks,
       ignoreVcsIgnores,
       ignoredNames, ->
         callback(projectPaths)

--- a/lib/project-view.coffee
+++ b/lib/project-view.coffee
@@ -37,7 +37,7 @@ class ProjectView extends FuzzyFinderView
     @disposables.add atom.config.onDidChange 'fuzzy-finder.ignoredNames', =>
       @reloadPaths = true
 
-    @disposables.add atom.config.onDidChange 'fuzzy-finder.traverseIntoSymlinkDirectories', =>
+    @disposables.add atom.config.onDidChange 'core.followSymlinks', =>
       @reloadPaths = true
 
     @disposables.add atom.config.onDidChange 'core.ignoredNames', =>

--- a/spec/fuzzy-finder-spec.coffee
+++ b/spec/fuzzy-finder-spec.coffee
@@ -164,8 +164,8 @@ describe 'FuzzyFinder', ->
               expect(projectView.list.find("li:contains(symlink-to-file)")).toExist()
               expect(projectView.list.find("li:contains(symlink-to-internal-file)")).not.toExist()
 
-          it "excludes symlinked folder paths if traverseIntoSymlinkDirectories is false", ->
-            atom.config.set('fuzzy-finder.traverseIntoSymlinkDirectories', false)
+          it "excludes symlinked folder paths if followSymlinks is false", ->
+            atom.config.set('core.followSymlinks', false)
 
             dispatchCommand('toggle-file-finder')
 
@@ -178,8 +178,8 @@ describe 'FuzzyFinder', ->
               expect(projectView.list.find("li:contains(symlink-to-internal-dir)")).not.toExist()
               expect(projectView.list.find("li:contains(symlink-to-internal-dir/a)")).not.toExist()
 
-          it "includes symlinked folder paths if traverseIntoSymlinkDirectories is true", ->
-            atom.config.set('fuzzy-finder.traverseIntoSymlinkDirectories', true)
+          it "includes symlinked folder paths if followSymlinks is true", ->
+            atom.config.set('core.followSymlinks', true)
 
             dispatchCommand('toggle-file-finder')
 


### PR DESCRIPTION
This currently has the issue of the linked files showing up twice.

![screen shot 2014-12-19 at 5 24 56 pm](https://cloud.githubusercontent.com/assets/69169/5513308/00b3f8aa-87a4-11e4-97ed-a0e13015166f.png)
