### PR TITLE
Remove ctrl-t keybinding for showing fuzzy finder on Linux and Windows

### DIFF
--- a/keymaps/fuzzy-finder.cson
+++ b/keymaps/fuzzy-finder.cson
@@ -5,13 +5,11 @@
   'cmd-B': 'fuzzy-finder:toggle-git-status-finder'
 
 '.platform-win32':
-  'ctrl-t': 'fuzzy-finder:toggle-file-finder'
   'ctrl-p': 'fuzzy-finder:toggle-file-finder'
   'ctrl-b': 'fuzzy-finder:toggle-buffer-finder'
   'ctrl-B': 'fuzzy-finder:toggle-git-status-finder'
 
 '.platform-linux':
-  'ctrl-t': 'fuzzy-finder:toggle-file-finder'
   'ctrl-p': 'fuzzy-finder:toggle-file-finder'
   'ctrl-b': 'fuzzy-finder:toggle-buffer-finder'
   'ctrl-B': 'fuzzy-finder:toggle-git-status-finder'


### PR DESCRIPTION
See https://github.com/atom/atom/pull/3050#issuecomment-49906731 for motivation. On OSX, `cmd+t` and `cmd+p` are still valid, and that matches the behavior in SublimeText (both keybinding are valid there as well on OSX, and for Linux/Win only `ctrl-p` is valid).

cc @kevinsawicki 
