### PR TITLE
Add option to preserve last search query

### DIFF
--- a/lib/fuzzy-finder-view.coffee
+++ b/lib/fuzzy-finder-view.coffee
@@ -28,6 +28,16 @@ class FuzzyFinderView extends SelectListView
   getFilterKey: ->
     'projectRelativePath'
 
+  cancel: ->
+    if atom.config.get('fuzzy-finder.preserveLastSearch')
+      lastSearch = @getFilterQuery()
+      super
+
+      @filterEditorView.setText(lastSearch)
+      @filterEditorView.getModel().selectAll()
+    else
+      super
+
   destroy: ->
     @cancel()
     @panel?.destroy()

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -6,6 +6,9 @@ module.exports =
     traverseIntoSymlinkDirectories:
       type: 'boolean'
       default: false
+    preserveLastSearch:
+      type: 'boolean'
+      default: false
 
   activate: (state) ->
     atom.commands.add 'atom-workspace',

--- a/spec/fuzzy-finder-spec.coffee
+++ b/spec/fuzzy-finder-spec.coffee
@@ -679,6 +679,33 @@ describe 'FuzzyFinder', ->
           expect(atom.workspace.getActiveTextEditor().getPath()).toBe editor1.getPath()
           expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual [3, 4]
 
+  describe "Preserve last search", ->
+    it "does not preserve last search by default", ->
+      dispatchCommand('toggle-file-finder')
+      expect(atom.workspace.panelForItem(projectView).isVisible()).toBe true
+      projectView.filterEditorView.getModel().insertText('this should not show up next time we open finder')
+
+      dispatchCommand('toggle-file-finder')
+      expect(atom.workspace.panelForItem(projectView).isVisible()).toBe false
+
+      dispatchCommand('toggle-file-finder')
+      expect(atom.workspace.panelForItem(projectView).isVisible()).toBe true
+      expect(projectView.filterEditorView.getText()).toBe ''
+
+    it "preserves last search when config is set", ->
+      atom.config.set("fuzzy-finder.preserveLastSearch", true)
+
+      dispatchCommand('toggle-file-finder')
+      expect(atom.workspace.panelForItem(projectView).isVisible()).toBe true
+      projectView.filterEditorView.getModel().insertText('this should show up next time we open finder')
+
+      dispatchCommand('toggle-file-finder')
+      expect(atom.workspace.panelForItem(projectView).isVisible()).toBe false
+
+      dispatchCommand('toggle-file-finder')
+      expect(atom.workspace.panelForItem(projectView).isVisible()).toBe true
+      expect(projectView.filterEditorView.getText()).toBe 'this should show up next time we open finder'
+
   describe "Git integration", ->
     [projectPath, gitRepository, gitDirectory] = []
 


### PR DESCRIPTION
When working, I love having minimal number of opened tabs. Thus, I close and open files all the time. This is kinda ingrained habit for me. I'm really used to flow of JetBrains products, because their fuzzy search remembers a query string of your previous search.

Lack of this option was always a deal breaker for me. But since Atom is so hackable, it was just few lines of code to make it work. What's your opinion on it?

![fuzzy](https://cloud.githubusercontent.com/assets/957321/6879093/2b87b6a8-d4ec-11e4-9f1c-232f63385d90.gif)

Here's a gif where I show pain of typing same query string two times. And then, after enabling this option where you can see the preserved query string so I can open file instantly. From this example it might seem I'm not aware of undo close tab shortcut. This is not the case. 

Better way to describe problem that this feature solves is that on our projects we have lots of files with similar names (models / views). When you open a model file you later on want to open view file too and you don't want to type same file name again.