### PR TITLE
Deduplicate fuzzy finder keybindings

### DIFF
--- a/keymaps/fuzzy-finder.cson
+++ b/keymaps/fuzzy-finder.cson
@@ -1,17 +1,14 @@
 '.platform-darwin':
   'cmd-t': 'fuzzy-finder:toggle-file-finder'
-  'cmd-p': 'fuzzy-finder:toggle-file-finder'
   'cmd-b': 'fuzzy-finder:toggle-buffer-finder'
   'cmd-B': 'fuzzy-finder:toggle-git-status-finder'
 
 '.platform-win32':
   'ctrl-t': 'fuzzy-finder:toggle-file-finder'
-  'ctrl-p': 'fuzzy-finder:toggle-file-finder'
   'ctrl-b': 'fuzzy-finder:toggle-buffer-finder'
   'ctrl-B': 'fuzzy-finder:toggle-git-status-finder'
 
 '.platform-linux':
   'ctrl-t': 'fuzzy-finder:toggle-file-finder'
-  'ctrl-p': 'fuzzy-finder:toggle-file-finder'
   'ctrl-b': 'fuzzy-finder:toggle-buffer-finder'
   'ctrl-B': 'fuzzy-finder:toggle-git-status-finder'


### PR DESCRIPTION
This will require a docs update, but opening for discussion as this came up in chat with @bolinfest.

Good keybindings are precious and rare, and we don't have to hew perfectly to sublime for new users. I understand that users can rebind commands as necessary, but as most users will likely stick to the defaults, I think we should pick one binding for the fuzzy finder and stick with it. I personally remapped cmd-p to the command palette literally the first day I started using Atom so I prefer to keep cmd-t but I know that's totally subjective and could be argued into doing this the other way.

cc: @bolinfest , @atom/core 