### PR TITLE
Do not follow symlinks internal to the root directory

### DIFF
--- a/lib/load-paths-handler.coffee
+++ b/lib/load-paths-handler.coffee
@@ -45,6 +45,7 @@ class PathLoader
     fs.lstat pathToLoad, (error, stats) =>
       return done() if error?
       if stats.isSymbolicLink()
+        return done() if fs.realpathSync(pathToLoad).search(@rootPath) is 0
         fs.stat pathToLoad, (error, stats) =>
           return done() if error?
           if stats.isFile()

--- a/spec/fuzzy-finder-spec.coffee
+++ b/spec/fuzzy-finder-spec.coffee
@@ -10,7 +10,7 @@ PathLoader = require '../lib/path-loader'
 
 describe 'FuzzyFinder', ->
   [rootDir1, rootDir2] = []
-  [projectView, bufferView, gitStatusView, workspaceElement] = []
+  [projectView, bufferView, gitStatusView, workspaceElement, fixturesPath] = []
 
   beforeEach ->
     rootDir1 = fs.realpathSync(temp.mkdirSync('root-dir1'))
@@ -142,9 +142,18 @@ describe 'FuzzyFinder', ->
             expect(projectView.list.find("li:eq(1)").text()).toContain('sample.html')
 
         describe "symlinks on #darwin or #linux", ->
+          [junkDirPath, junkFilePath] = []
           beforeEach ->
-            fs.symlinkSync(atom.project.getDirectories()[0].resolve('sample.txt'), atom.project.getDirectories()[0].resolve('symlink-to-file'))
-            fs.symlinkSync(atom.project.getDirectories()[0].resolve('dir'), atom.project.getDirectories()[0].resolve('symlink-to-dir'))
+            junkDirPath = fs.realpathSync(temp.mkdirSync('junk-1'))
+            junkFilePath = path.join(junkDirPath, 'file.txt')
+            fs.writeFileSync(junkFilePath, 'txt')
+            fs.writeFileSync(path.join(junkDirPath, 'a'), 'txt')
+
+            fs.symlinkSync(junkFilePath, atom.project.getDirectories()[0].resolve('symlink-to-file'))
+            fs.symlinkSync(junkDirPath, atom.project.getDirectories()[0].resolve('symlink-to-dir'))
+
+            fs.symlinkSync(atom.project.getDirectories()[0].resolve('sample.txt'), atom.project.getDirectories()[0].resolve('symlink-to-internal-file'))
+            fs.symlinkSync(atom.project.getDirectories()[0].resolve('dir'), atom.project.getDirectories()[0].resolve('symlink-to-internal-dir'))
 
           it "includes symlinked file paths", ->
             dispatchCommand('toggle-file-finder')
@@ -153,6 +162,7 @@ describe 'FuzzyFinder', ->
 
             runs ->
               expect(projectView.list.find("li:contains(symlink-to-file)")).toExist()
+              expect(projectView.list.find("li:contains(symlink-to-internal-file)")).not.toExist()
 
           it "excludes symlinked folder paths if traverseIntoSymlinkDirectories is false", ->
             atom.config.set('fuzzy-finder.traverseIntoSymlinkDirectories', false)
@@ -165,6 +175,9 @@ describe 'FuzzyFinder', ->
               expect(projectView.list.find("li:contains(symlink-to-dir)")).not.toExist()
               expect(projectView.list.find("li:contains(symlink-to-dir/a)")).not.toExist()
 
+              expect(projectView.list.find("li:contains(symlink-to-internal-dir)")).not.toExist()
+              expect(projectView.list.find("li:contains(symlink-to-internal-dir/a)")).not.toExist()
+
           it "includes symlinked folder paths if traverseIntoSymlinkDirectories is true", ->
             atom.config.set('fuzzy-finder.traverseIntoSymlinkDirectories', true)
 
@@ -174,6 +187,7 @@ describe 'FuzzyFinder', ->
 
             runs ->
               expect(projectView.list.find("li:contains(symlink-to-dir/a)")).toExist()
+              expect(projectView.list.find("li:contains(symlink-to-internal-dir/a)")).not.toExist()
 
         describe "socket files on #darwin or #linux", ->
           [socketServer, socketPath] = []


### PR DESCRIPTION
This will only follow symlinks outside the root directory, removing duplicates in the results:

Before 
![screen shot 2015-04-13 at 6 24 10 pm](https://cloud.githubusercontent.com/assets/69169/7128706/daaad89c-e20a-11e4-878a-c4b4dcf9dd63.png)

After
![screen shot 2015-04-13 at 6 23 49 pm](https://cloud.githubusercontent.com/assets/69169/7128707/de2fa77c-e20a-11e4-971f-c78cbe8789e2.png)

