### PR TITLE
Add feature to search through all open panes instead of just active pane

### DIFF
--- a/keymaps/fuzzy-finder.cson
+++ b/keymaps/fuzzy-finder.cson
@@ -3,18 +3,18 @@
   'cmd-p': 'fuzzy-finder:toggle-file-finder'
   'cmd-b': 'fuzzy-finder:toggle-buffer-finder'
   'cmd-B': 'fuzzy-finder:toggle-git-status-finder'
-  'shift-enter': 'fuzzy-finder:alternate-confirm'
+  'shift-enter': 'fuzzy-finder:invert-confirm'
 
 '.platform-win32':
   'ctrl-t': 'fuzzy-finder:toggle-file-finder'
   'ctrl-p': 'fuzzy-finder:toggle-file-finder'
   'ctrl-b': 'fuzzy-finder:toggle-buffer-finder'
   'ctrl-B': 'fuzzy-finder:toggle-git-status-finder'
-  'shift-enter': 'fuzzy-finder:alternate-confirm'
+  'shift-enter': 'fuzzy-finder:invert-confirm'
 
 '.platform-linux':
   'ctrl-t': 'fuzzy-finder:toggle-file-finder'
   'ctrl-p': 'fuzzy-finder:toggle-file-finder'
   'ctrl-b': 'fuzzy-finder:toggle-buffer-finder'
   'ctrl-B': 'fuzzy-finder:toggle-git-status-finder'
-  'shift-enter': 'fuzzy-finder:alternate-confirm'
+  'shift-enter': 'fuzzy-finder:invert-confirm'

--- a/keymaps/fuzzy-finder.cson
+++ b/keymaps/fuzzy-finder.cson
@@ -3,15 +3,18 @@
   'cmd-p': 'fuzzy-finder:toggle-file-finder'
   'cmd-b': 'fuzzy-finder:toggle-buffer-finder'
   'cmd-B': 'fuzzy-finder:toggle-git-status-finder'
+  'shift-enter': 'fuzzy-finder:alternate-confirm'
 
 '.platform-win32':
   'ctrl-t': 'fuzzy-finder:toggle-file-finder'
   'ctrl-p': 'fuzzy-finder:toggle-file-finder'
   'ctrl-b': 'fuzzy-finder:toggle-buffer-finder'
   'ctrl-B': 'fuzzy-finder:toggle-git-status-finder'
+  'shift-enter': 'fuzzy-finder:alternate-confirm'
 
 '.platform-linux':
   'ctrl-t': 'fuzzy-finder:toggle-file-finder'
   'ctrl-p': 'fuzzy-finder:toggle-file-finder'
   'ctrl-b': 'fuzzy-finder:toggle-buffer-finder'
   'ctrl-B': 'fuzzy-finder:toggle-git-status-finder'
+  'shift-enter': 'fuzzy-finder:alternate-confirm'

--- a/lib/fuzzy-finder-view.coffee
+++ b/lib/fuzzy-finder-view.coffee
@@ -24,6 +24,8 @@ class FuzzyFinderView extends SelectListView
         @splitOpenPath (pane, item) -> pane.splitDown(items: [item])
       'pane:split-up': =>
         @splitOpenPath (pane, item) -> pane.splitUp(items: [item])
+      'fuzzy-finder:alternate-confirm': =>
+        @confirmAlternateSelection()
 
   getFilterKey: ->
     'projectRelativePath'
@@ -61,9 +63,10 @@ class FuzzyFinderView extends SelectListView
         @div fileBasename, class: "primary-line file icon #{typeClass}", 'data-name': fileBasename, 'data-path': projectRelativePath
         @div projectRelativePath, class: 'secondary-line path no-icon'
 
-  openPath: (filePath, lineNumber) ->
+  openPath: (filePath, lineNumber, searchAllPanes) ->
     if filePath
-      atom.workspace.open(filePath).done => @moveToLine(lineNumber)
+      if not atom.workspace.getActivePane().activateItemForURI(filePath)
+          atom.workspace.open(filePath, searchAllPanes: searchAllPanes ).done => @moveToLine(lineNumber)
 
   moveToLine: (lineNumber=-1) ->
     return unless lineNumber >= 0
@@ -100,9 +103,13 @@ class FuzzyFinderView extends SelectListView
 
   confirmSelection: ->
     item = @getSelectedItem()
-    @confirmed(item)
+    @confirmed(item, atom.config.get 'fuzzy-finder.searchAllPanes')
 
-  confirmed: ({filePath}={}) ->
+  confirmAlternateSelection: ->
+    item = @getSelectedItem()
+    @confirmed(item, !atom.config.get 'fuzzy-finder.searchAllPanes')
+
+  confirmed: ({filePath}={}, searchAllPanes) ->
     if atom.workspace.getActiveTextEditor() and @isQueryALineJump()
       lineNumber = @getLineNumber()
       @cancel()
@@ -115,7 +122,7 @@ class FuzzyFinderView extends SelectListView
     else
       lineNumber = @getLineNumber()
       @cancel()
-      @openPath(filePath, lineNumber)
+      @openPath(filePath, lineNumber, searchAllPanes)
 
   isQueryALineJump: ->
     query = @filterEditorView.getModel().getText()

--- a/lib/fuzzy-finder-view.coffee
+++ b/lib/fuzzy-finder-view.coffee
@@ -65,8 +65,10 @@ class FuzzyFinderView extends SelectListView
 
   openPath: (filePath, lineNumber, searchAllPanes) ->
     if filePath
-      if not atom.workspace.getActivePane().activateItemForURI(filePath)
-          atom.workspace.open(filePath, searchAllPanes: searchAllPanes ).done => @moveToLine(lineNumber)
+      if atom.workspace.getActivePane().activateItemForURI(filePath)
+        @moveToLine(lineNumber)
+      else
+        atom.workspace.open(filePath, searchAllPanes: searchAllPanes ).done => @moveToLine(lineNumber)
 
   moveToLine: (lineNumber=-1) ->
     return unless lineNumber >= 0

--- a/lib/fuzzy-finder-view.coffee
+++ b/lib/fuzzy-finder-view.coffee
@@ -24,8 +24,8 @@ class FuzzyFinderView extends SelectListView
         @splitOpenPath (pane, item) -> pane.splitDown(items: [item])
       'pane:split-up': =>
         @splitOpenPath (pane, item) -> pane.splitUp(items: [item])
-      'fuzzy-finder:alternate-confirm': =>
-        @confirmAlternateSelection()
+      'fuzzy-finder:invert-confirm': =>
+        @confirmInvertedSelection()
 
   getFilterKey: ->
     'projectRelativePath'
@@ -65,10 +65,7 @@ class FuzzyFinderView extends SelectListView
 
   openPath: (filePath, lineNumber, searchAllPanes) ->
     if filePath
-      if atom.workspace.getActivePane().activateItemForURI(filePath)
-        @moveToLine(lineNumber)
-      else
-        atom.workspace.open(filePath, searchAllPanes: searchAllPanes ).done => @moveToLine(lineNumber)
+      atom.workspace.open(filePath, searchAllPanes: searchAllPanes ).done => @moveToLine(lineNumber)
 
   moveToLine: (lineNumber=-1) ->
     return unless lineNumber >= 0
@@ -107,7 +104,7 @@ class FuzzyFinderView extends SelectListView
     item = @getSelectedItem()
     @confirmed(item, atom.config.get 'fuzzy-finder.searchAllPanes')
 
-  confirmAlternateSelection: ->
+  confirmInvertedSelection: ->
     item = @getSelectedItem()
     @confirmed(item, !atom.config.get 'fuzzy-finder.searchAllPanes')
 

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -3,6 +3,10 @@ module.exports =
     ignoredNames:
       type: 'array'
       default: []
+    searchAllPanes:
+      description: "Whether to search through all open panes or just the active one. Holding shift inverts this setting."
+      type: 'boolean'
+      default: false
 
   activate: (state) ->
     @active = true

--- a/spec/fuzzy-finder-spec.coffee
+++ b/spec/fuzzy-finder-spec.coffee
@@ -422,9 +422,6 @@ describe 'FuzzyFinder', ->
             expect(atom.views.getView(editor3)).toHaveFocus()
 
       describe "when the active pane does not have an item for the selected path and fuzzy-finder.searchAllPanes is false", ->
-        beforeEach ->
-          atom.config.set("fuzzy-finder.searchAllPanes", false)
-
         it "adds a new item to the active pane for the selected path", ->
           dispatchCommand('toggle-buffer-finder')
 

--- a/spec/fuzzy-finder-spec.coffee
+++ b/spec/fuzzy-finder-spec.coffee
@@ -404,9 +404,6 @@ describe 'FuzzyFinder', ->
           dispatchCommand('toggle-buffer-finder')
 
       describe "when the active pane has an item for the selected path", ->
-        beforeEach ->
-          atom.config.set("fuzzy-finder.searchAllPanes", false)
-
         it "switches to the item for the selected path", ->
           expectedPath = atom.project.getDirectories()[0].resolve('sample.txt')
           bufferView.confirmed({filePath: expectedPath})


### PR DESCRIPTION
Fixes #34: Add feature to search through all open panes instead of just the active one, a preference to control this, and the ability to invert the current preference with Shift-Enter.

@izuzak Sorry about creating a second PR, I got confused about how to rebase and screwed up the other branch.