### PR TITLE
Remove 'cmd-t' / 'ctrl-t' for 'toggle-file-finder'

### DIFF
--- a/keymaps/fuzzy-finder.cson
+++ b/keymaps/fuzzy-finder.cson
@@ -1,17 +1,14 @@
 '.platform-darwin':
-  'cmd-t': 'fuzzy-finder:toggle-file-finder'
   'cmd-p': 'fuzzy-finder:toggle-file-finder'
   'cmd-b': 'fuzzy-finder:toggle-buffer-finder'
   'cmd-B': 'fuzzy-finder:toggle-git-status-finder'
 
 '.platform-win32':
-  'ctrl-t': 'fuzzy-finder:toggle-file-finder'
   'ctrl-p': 'fuzzy-finder:toggle-file-finder'
   'ctrl-b': 'fuzzy-finder:toggle-buffer-finder'
   'ctrl-B': 'fuzzy-finder:toggle-git-status-finder'
 
 '.platform-linux':
-  'ctrl-t': 'fuzzy-finder:toggle-file-finder'
   'ctrl-p': 'fuzzy-finder:toggle-file-finder'
   'ctrl-b': 'fuzzy-finder:toggle-buffer-finder'
   'ctrl-B': 'fuzzy-finder:toggle-git-status-finder'


### PR DESCRIPTION
Replaces #92 and #78 
See https://github.com/atom/fuzzy-finder/pull/92#issuecomment-107597085

----

The `ctrl-` and `cmd-` keybindings are a precious resource. Having two for the same package is :panda_face:.

However I agree that we'd need to remove `cmd-t` / `ctrl-t`
 - We have `ctrl-shift-p` for the command panel
 - We could have `ctrl-alt-p` for a project switcher (the spec runner doesn't need a keyboard shortcut as the average user doesn't care)
 - It mimics sublime in a very obvious way