### PR TITLE
Preview selected files in list #5

### DIFF
--- a/lib/fuzzy-finder-view.coffee
+++ b/lib/fuzzy-finder-view.coffee
@@ -28,6 +28,12 @@ class FuzzyFinderView extends SelectListView
       'fuzzy-finder:invert-confirm': =>
         @confirmInvertedSelection()
 
+    atom.commands.add '.fuzzy-finder',
+      'core:move-down': =>
+        @previewSelection()
+      'core:move-up': =>
+        @previewSelection()
+
   getFilterKey: ->
     'projectRelativePath'
 
@@ -138,6 +144,11 @@ class FuzzyFinderView extends SelectListView
       @setError('Jump to line in active editor')
     else
       super
+
+  previewSelection: ->
+    {filePath} = @getSelectedItem() ? {}
+    lineNumber = @getLineNumber()
+    @openPath(filePath, lineNumber, {searchAllPanes: atom.config.get('fuzzy-finder.searchAllPanes'), activatePane: false})
 
   confirmSelection: ->
     item = @getSelectedItem()

--- a/lib/fuzzy-finder-view.coffee
+++ b/lib/fuzzy-finder-view.coffee
@@ -111,9 +111,12 @@ class FuzzyFinderView extends SelectListView
         atom.workspace.open(filePath, openOptions).done => @moveToLine(lineNumber)
       else
         atom.workspace.open(filePath, openOptions).done (editor) =>
-          editorElement = atom.views.getView(editor)
-          atom.commands.dispatch(editorElement, 'tabs:keep-preview-tab')
+          @clearPreview(editor)
           @moveToLine(lineNumber)
+
+  clearPreview: (editor) ->
+    editorElement = atom.views.getView(editor)
+    atom.commands.dispatch(editorElement, 'tabs:keep-preview-tab')
 
   moveToLine: (lineNumber=-1) ->
     return unless lineNumber >= 0

--- a/lib/fuzzy-finder-view.coffee
+++ b/lib/fuzzy-finder-view.coffee
@@ -146,9 +146,10 @@ class FuzzyFinderView extends SelectListView
       super
 
   previewSelection: ->
-    {filePath} = @getSelectedItem() ? {}
-    lineNumber = @getLineNumber()
-    @openPath(filePath, lineNumber, {searchAllPanes: atom.config.get('fuzzy-finder.searchAllPanes'), activatePane: false})
+    if atom.config.get('fuzzy-finder.previewSelection')
+      {filePath} = @getSelectedItem() ? {}
+      lineNumber = @getLineNumber()
+      @openPath(filePath, lineNumber, {searchAllPanes: atom.config.get('fuzzy-finder.searchAllPanes'), activatePane: false})
 
   confirmSelection: ->
     item = @getSelectedItem()

--- a/lib/fuzzy-finder-view.coffee
+++ b/lib/fuzzy-finder-view.coffee
@@ -9,6 +9,7 @@ module.exports =
 class FuzzyFinderView extends SelectListView
   filePaths: null
   projectRelativePaths: null
+  lastSearch: ''
 
   initialize: ->
     super
@@ -39,13 +40,9 @@ class FuzzyFinderView extends SelectListView
 
   cancel: ->
     if atom.config.get('fuzzy-finder.preserveLastSearch')
-      lastSearch = @getFilterQuery()
-      super
-
-      @filterEditorView.setText(lastSearch)
-      @filterEditorView.getModel().selectAll()
-    else
-      super
+      @lastSearch = @getFilterQuery()
+    super
+    @cancelling = true
 
   destroy: ->
     @cancel()
@@ -150,6 +147,7 @@ class FuzzyFinderView extends SelectListView
       @setError('Jump to line in active editor')
     else
       super
+      @previewSelection() if not @reloadPaths
 
   previewSelection: ->
     if atom.config.get('fuzzy-finder.previewSelection')
@@ -222,6 +220,9 @@ class FuzzyFinderView extends SelectListView
     @projectRelativePaths
 
   show: ->
+    if atom.config.get('fuzzy-finder.preserveLastSearch')
+      @filterEditorView.setText(@lastSearch)
+      @filterEditorView.getModel().selectAll()
     @storeFocusedElement()
     @panel ?= atom.workspace.addModalPanel(item: this)
     @panel.show()

--- a/lib/fuzzy-finder-view.coffee
+++ b/lib/fuzzy-finder-view.coffee
@@ -144,6 +144,7 @@ class FuzzyFinderView extends SelectListView
       @setError('Jump to line in active editor')
     else
       super
+    @previewSelection()
 
   previewSelection: ->
     if atom.config.get('fuzzy-finder.previewSelection')

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -10,6 +10,9 @@ module.exports =
     preserveLastSearch:
       type: 'boolean'
       default: false
+    previewSelection:
+      type: 'boolean'
+      default: false
 
   activate: (state) ->
     @active = true

--- a/lib/project-view.coffee
+++ b/lib/project-view.coffee
@@ -67,8 +67,6 @@ class ProjectView extends FuzzyFinderView
       @setItems([])
       return
 
-    @previewSelection()
-
     if @reloadPaths
       @reloadPaths = false
 

--- a/lib/project-view.coffee
+++ b/lib/project-view.coffee
@@ -67,6 +67,8 @@ class ProjectView extends FuzzyFinderView
       @setItems([])
       return
 
+    @previewSelection()
+
     if @reloadPaths
       @reloadPaths = false
 

--- a/spec/fuzzy-finder-spec.coffee
+++ b/spec/fuzzy-finder-spec.coffee
@@ -474,6 +474,29 @@ describe 'FuzzyFinder', ->
             expect(atom.workspace.getPaneItems().length).toBe 3
 
   describe "common behavior between file and buffer finder", ->
+
+    describe "when a path is selected", ->
+      it "previews the file associated with that path", ->
+        jasmine.attachToDOM(workspaceElement)
+
+        dispatchCommand('toggle-file-finder')
+
+        projectView.setMaxItems(Infinity)
+        waitForPathsToDisplay(projectView)
+        runs ->
+          editor = atom.workspace.getActiveTextEditor()
+          projectViewElement = workspaceElement.querySelector('.fuzzy-finder')
+          spyOn(projectView, 'previewSelection')
+          expect(projectView.getSelectedItem().filePath).toBe projectView.filePaths[0]
+
+          atom.commands.dispatch(projectViewElement, 'core:move-down')
+          expect(projectView.getSelectedItem().filePath).toBe projectView.filePaths[1]
+          expect(projectView.previewSelection.callCount).toBe 1
+
+          atom.commands.dispatch(projectViewElement, 'core:move-up')
+          expect(projectView.getSelectedItem().filePath).toBe projectView.filePaths[0]
+          expect(projectView.previewSelection.callCount).toBe 2
+
     describe "when the fuzzy finder is cancelled", ->
       describe "when an editor is open", ->
         it "detaches the finder and focuses the previously focused element", ->

--- a/spec/fuzzy-finder-spec.coffee
+++ b/spec/fuzzy-finder-spec.coffee
@@ -476,7 +476,7 @@ describe 'FuzzyFinder', ->
   describe "common behavior between file and buffer finder", ->
 
     describe "when a path is selected", ->
-      fit "previews the file associated with that path if option is set", ->
+      it "previews the file associated with that path if option is set", ->
         atom.config.set("fuzzy-finder.previewSelection", true)
         projectView.setMaxItems(Infinity)
         spyOn(projectView, 'previewSelection')

--- a/spec/fuzzy-finder-spec.coffee
+++ b/spec/fuzzy-finder-spec.coffee
@@ -502,15 +502,15 @@ describe 'FuzzyFinder', ->
           editor = atom.workspace.getActiveTextEditor()
           projectViewElement = workspaceElement.querySelector('.fuzzy-finder')
           expect(projectView.getSelectedItem().filePath).toBe projectView.filePaths[0]
-          expect(projectView.previewSelection.callCount).toBe 1
+          expect(projectView.previewSelection.callCount).toBe 0
 
           atom.commands.dispatch(projectViewElement, 'core:move-down')
           expect(projectView.getSelectedItem().filePath).toBe projectView.filePaths[1]
-          expect(projectView.previewSelection.callCount).toBe 2
+          expect(projectView.previewSelection.callCount).toBe 1
 
           atom.commands.dispatch(projectViewElement, 'core:move-up')
           expect(projectView.getSelectedItem().filePath).toBe projectView.filePaths[0]
-          expect(projectView.previewSelection.callCount).toBe 3
+          expect(projectView.previewSelection.callCount).toBe 2
 
     describe "when the fuzzy finder is cancelled", ->
       describe "when an editor is open", ->

--- a/spec/fuzzy-finder-spec.coffee
+++ b/spec/fuzzy-finder-spec.coffee
@@ -476,7 +476,8 @@ describe 'FuzzyFinder', ->
   describe "common behavior between file and buffer finder", ->
 
     describe "when a path is selected", ->
-      it "previews the file associated with that path", ->
+      it "previews the file associated with that path if option is set", ->
+        atom.config.set("fuzzy-finder.previewSelection", true)
         jasmine.attachToDOM(workspaceElement)
 
         dispatchCommand('toggle-file-finder')

--- a/spec/fuzzy-finder-spec.coffee
+++ b/spec/fuzzy-finder-spec.coffee
@@ -476,27 +476,28 @@ describe 'FuzzyFinder', ->
   describe "common behavior between file and buffer finder", ->
 
     describe "when a path is selected", ->
-      it "previews the file associated with that path if option is set", ->
+      fit "previews the file associated with that path if option is set", ->
         atom.config.set("fuzzy-finder.previewSelection", true)
+        projectView.setMaxItems(Infinity)
+        spyOn(projectView, 'previewSelection')
         jasmine.attachToDOM(workspaceElement)
 
         dispatchCommand('toggle-file-finder')
 
-        projectView.setMaxItems(Infinity)
         waitForPathsToDisplay(projectView)
         runs ->
           editor = atom.workspace.getActiveTextEditor()
           projectViewElement = workspaceElement.querySelector('.fuzzy-finder')
-          spyOn(projectView, 'previewSelection')
           expect(projectView.getSelectedItem().filePath).toBe projectView.filePaths[0]
+          expect(projectView.previewSelection.callCount).toBe 1
 
           atom.commands.dispatch(projectViewElement, 'core:move-down')
           expect(projectView.getSelectedItem().filePath).toBe projectView.filePaths[1]
-          expect(projectView.previewSelection.callCount).toBe 1
+          expect(projectView.previewSelection.callCount).toBe 2
 
           atom.commands.dispatch(projectViewElement, 'core:move-up')
           expect(projectView.getSelectedItem().filePath).toBe projectView.filePaths[0]
-          expect(projectView.previewSelection.callCount).toBe 2
+          expect(projectView.previewSelection.callCount).toBe 3
 
     describe "when the fuzzy finder is cancelled", ->
       describe "when an editor is open", ->


### PR DESCRIPTION
Ok folks, you asked for it.  Here is the new feature for previewing selected files.

To enable this feature, go into **fuzzy-finder** Settings and check the new "Preview Selection" option:

<img width="295" alt="screen shot 2015-07-03 at 10 25 34 pm" src="https://cloud.githubusercontent.com/assets/5921938/8506636/74f54358-21d3-11e5-85fa-efae6638f355.png">

Obviously, this works best if you have "Use Preview Tabs" option turned on from the **tab** package Settings.
