### PR TITLE
Remove leading './'

### DIFF
--- a/lib/fuzzy-finder-view.coffee
+++ b/lib/fuzzy-finder-view.coffee
@@ -173,6 +173,8 @@ class FuzzyFinderView extends SelectListView
     query = super
     colon = query.indexOf(':')
     query = query[0...colon] if colon isnt -1
+    # Remove leading './'
+    query = query.replace(/^\.\//, '')
     # Normalize to backslashes on Windows
     query = query.replace(/\//g, '\\') if process.platform is 'win32'
     query

--- a/spec/fuzzy-finder-spec.coffee
+++ b/spec/fuzzy-finder-spec.coffee
@@ -662,6 +662,27 @@ describe 'FuzzyFinder', ->
         expect(atom.workspace.getActivePane()).toBe bottomPane
         expect(atom.workspace.getActiveTextEditor().getPath()).toBe atom.project.getDirectories()[0].resolve(filePath)
 
+  describe "when the filter text starts with a dot followed by a slash", ->
+    beforeEach ->
+      jasmine.attachToDOM(workspaceElement)
+      expect(atom.workspace.panelForItem(projectView)).toBeNull()
+
+      waitsForPromise ->
+        atom.workspace.open('sample.txt')
+
+    describe "when the filter text has a file path", ->
+      it "removes leading './'", ->
+        debugger
+        [editor1, editor2] = atom.workspace.getTextEditors()
+
+        dispatchCommand('toggle-buffer-finder')
+        expect(atom.workspace.panelForItem(bufferView).isVisible()).toBe true
+
+        bufferView.filterEditorView.getModel().setText('./sample.js')
+        bufferView.populateList()
+        {filePath} = bufferView.getSelectedItem()
+        expect(atom.project.getDirectories()[0].resolve(filePath)).toBe editor1.getPath()
+
   describe "when the filter text contains a colon followed by a number", ->
     beforeEach ->
       jasmine.attachToDOM(workspaceElement)


### PR DESCRIPTION
Rspec reports failed examples as

```
./path/to/file.rb
```

When double clicking on the path in order to copy it, `./` gets copied too, which is why I would like to have it filtered out in the fuzzy finder.
#### TODOs:
- [ ] Currently, '`./file` will find `file.rb`, even without the path. Should this only find complete paths?
- [ ] I added a spec that didn't pass before, but passes now, so I'm assuming that's okay. However, in other specs there are more expectations, so I'm not sure if I should check if the correct file is opened etc.
