### PR TITLE
Option to show closed buffers too

### DIFF
--- a/lib/closed-buffers.coffee
+++ b/lib/closed-buffers.coffee
@@ -1,0 +1,43 @@
+{CompositeDisposable} = require 'atom'
+_ = require 'underscore-plus'
+
+module.exports =
+class ClosedBuffers
+  constructor: ->
+    @items = {}
+    @disposables = new CompositeDisposable
+
+    @disposables.add atom.workspace.onDidDestroyPaneItem ({item}) =>
+      @ifItemHasPath item, (path, item) =>
+        @addPath(path, item.lastOpened)
+
+    @disposables.add atom.workspace.onDidOpen ({item}) =>
+      @ifItemHasPath item, (path) =>
+        @deletePath(path)
+
+    @disposables.add atom.config.observe 'fuzzy-finder.maxClosedBuffersToRemember', (max) =>
+      @limitPathsToRemember(max)
+
+  ifItemHasPath: (item, fn) ->
+    path = item.getPath?()
+    if path
+      fn(path, item)
+
+  addPath: (path, lastOpened) ->
+    limit = atom.config.get('fuzzy-finder.maxClosedBuffersToRemember')
+    if limit > 0
+      @items[path] = Date.now()
+      @limitPathsToRemember(limit)
+
+  deletePath: (path) ->
+    delete @items[path]
+
+  limitPathsToRemember: (max) ->
+    keys = _.keys(@items)
+    overflow = keys.length - max
+    if overflow > 0
+      _.times overflow, (i) =>
+        @deletePath(keys[i])
+
+  dispose: ->
+    @disposables.dispose()

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -1,3 +1,5 @@
+ClosedBuffers = require './closed-buffers'
+
 module.exports =
   config:
     ignoredNames:
@@ -10,9 +12,16 @@ module.exports =
     preserveLastSearch:
       type: 'boolean'
       default: false
+    maxClosedBuffersToRemember:
+      description: "The maximum count of closed buffers to show in the buffers list. Zero value means it's disabled"
+      type: 'number'
+      default: 0
+      minimum: 0
+      maximum: 100
 
   activate: (state) ->
     @active = true
+    @closedBuffers = new ClosedBuffers()
 
     atom.commands.add 'atom-workspace',
       'fuzzy-finder:toggle-file-finder': =>
@@ -41,6 +50,7 @@ module.exports =
       @gitStatusView.destroy()
       @gitStatusView = null
     @projectPaths = null
+    @closedBuffers.dispose()
     @stopLoadPathsTask()
     @active = false
 
@@ -69,7 +79,7 @@ module.exports =
   createBufferView: ->
     unless @bufferView?
       BufferView = require './buffer-view'
-      @bufferView = new BufferView()
+      @bufferView = new BufferView(@closedBuffers)
     @bufferView
 
   startLoadPathsTask: ->

--- a/spec/fuzzy-finder-spec.coffee
+++ b/spec/fuzzy-finder-spec.coffee
@@ -331,6 +331,17 @@ describe 'FuzzyFinder', ->
             expect(_.pluck(bufferView.list.find('li > div.file'), 'outerText')).toEqual ['sample-with-tabs.coffee', 'sample.js', 'sample.txt']
             expect(bufferView.list.children().first()).toHaveClass 'selected'
 
+        it 'do not list any closed buffers', ->
+          waitsForPromise ->
+            atom.workspace.open 'sample.html'
+
+          runs ->
+            atom.workspace.getActivePane().destroyActiveItem()
+            dispatchCommand('toggle-buffer-finder')
+            expect(atom.workspace.panelForItem(bufferView).isVisible()).toBe true
+            expect(_.pluck(bufferView.list.find('li > div.file'), 'outerText')).toEqual ['sample.js', 'sample.txt']
+            expect(bufferView.list.children().first()).toHaveClass 'selected'
+
         it "serializes the list of paths and their last opened time", ->
           waitsForPromise ->
             atom.workspace.open 'sample-with-tabs.coffee'
@@ -358,6 +369,52 @@ describe 'FuzzyFinder', ->
             for [time, bufferPath] in states
               expect(_.last bufferPath.split path.sep).toBe paths.shift()
               expect(time).toBeGreaterThan 50000
+
+        describe 'when the maxClosedBuffersToRemember config is set to a non-zero value', ->
+          beforeEach ->
+            atom.config.set('fuzzy-finder.maxClosedBuffersToRemember', 3)
+
+          describe 'when there are a bunch of buffers that have been closed', ->
+            beforeEach ->
+              # sample.js and sample.txt are already opened (from parent beforeEach)
+              # open a bunch of new files but close them immediately
+              waitsForPromise ->
+                atom.workspace.getActivePane().destroyActiveItem()
+                advanceClock(10)
+                atom.workspace.open 'sample-with-tabs.coffee'
+              waitsForPromise ->
+                atom.workspace.getActivePane().destroyActiveItem()
+                advanceClock(10)
+                atom.workspace.open 'a'
+              waitsForPromise ->
+                atom.workspace.getActivePane().destroyActiveItem()
+                advanceClock(10)
+                atom.workspace.open 'b'
+              waitsForPromise ->
+                atom.workspace.getActivePane().destroyActiveItem()
+                advanceClock(10)
+                atom.workspace.open 'sample.html'
+
+              waitsForPromise ->
+                # re-open one of the closed buffer, new "current item"
+                atom.workspace.getActivePane().destroyActiveItem()
+                advanceClock(10)
+                atom.workspace.open 'sample.html'
+
+            it 'lists the paths of the current items+closed buffers within max limit, sorted by most recently opened but with the current item last', ->
+              dispatchCommand('toggle-buffer-finder')
+              expect(atom.workspace.panelForItem(bufferView).isVisible()).toBe true
+              expect(_.pluck(bufferView.list.find('li > div.file'), 'outerText')).toEqual ['sample.js', 'b', 'a', 'sample.html']
+
+            describe 'when modifies the config setting', ->
+              beforeEach ->
+                atom.config.set('fuzzy-finder.maxClosedBuffersToRemember', 1)
+
+              it 'limit the closed buffers list accordingly', ->
+                # should cut out 'a' and 'b' from above
+                dispatchCommand('toggle-buffer-finder')
+                expect(atom.workspace.panelForItem(bufferView).isVisible()).toBe true
+                expect(_.pluck(bufferView.list.find('li > div.file'), 'outerText')).toEqual ['sample.js', 'b', 'sample.html']
 
       describe "when there are only panes with anonymous items", ->
         it "does not open", ->


### PR DESCRIPTION
![remember](https://cloud.githubusercontent.com/assets/978461/9425046/b1775e96-4902-11e5-9351-fc3773f3df97.gif)

This introduces an additional (opt-in) config setting to show be able to see recently-used-but-closed-buffers in the buffer view. The config setting defines how many closed buffers to remember (0 by default, i.e. the buffer view works just like now).

This is more or less the same functionality as I implemented in the package [recent-files-fuzzy-finder](https://github.com/viddo/recent-files-fuzzy-finder/blob/master/lib/recent-files-view.coffee), but considering I had to do some [workarounds/hacks](https://github.com/viddo/recent-files-fuzzy-finder/blob/master/lib/recent-files-view.coffee#L2-L6) to extend the buffer view I think it makes more sense to just add this as an additional (opt-in) behaviour in this package.

For some motivation to this feature see [recent-files-fuzzy-finder/readme#why](https://github.com/viddo/recent-files-fuzzy-finder#why)