### PR TITLE
:bug: Use VCS ignored even when in a subdirectory

### DIFF
--- a/lib/load-paths-handler.coffee
+++ b/lib/load-paths-handler.coffee
@@ -11,10 +11,7 @@ class PathLoader
   constructor: (@rootPath, ignoreVcsIgnores, @traverseSymlinkDirectories, @ignoredNames) ->
     @paths = []
     @realPathCache = {}
-    @repo = null
-    if ignoreVcsIgnores
-      repo = GitRepository.open(@rootPath, refreshOnWindowFocus: false)
-      @repo = repo if repo?.relativize(path.join(@rootPath, 'test')) is 'test'
+    @repo = if ignoreVcsIgnores then GitRepository.open(@rootPath, refreshOnWindowFocus: false) else null
 
   load: (done) ->
     @loadPath @rootPath, =>
@@ -23,10 +20,10 @@ class PathLoader
       done()
 
   isIgnored: (loadedPath) ->
-    relativePath = path.relative(@rootPath, loadedPath)
-    if @repo?.isPathIgnored(relativePath)
+    if @repo?.isPathIgnored(loadedPath)
       true
     else
+      relativePath = path.relative(@rootPath, loadedPath)
       for ignoredName in @ignoredNames
         return true if ignoredName.match(relativePath)
 


### PR DESCRIPTION
PathLoader only checks for VCS ignores when the active working directory is the root of the VCS. This commit will change that to use GitRepository.isPathIgnored even when working in a subdirectory.

Fixes #120