### PR TITLE
Add optional query parameter to fuzzy-finder:toggle* commands

### DIFF
--- a/lib/buffer-view.coffee
+++ b/lib/buffer-view.coffee
@@ -3,11 +3,12 @@ FuzzyFinderView = require './fuzzy-finder-view'
 
 module.exports =
 class BufferView extends FuzzyFinderView
-  toggle: ->
+  toggle: (query) ->
     if @panel?.isVisible()
       @cancel()
     else
       @populate()
+      @setFilterQuery(query) if query?
       @show() if @paths?.length > 0
 
   getEmptyMessage: (itemCount) ->

--- a/lib/fuzzy-finder-view.coffee
+++ b/lib/fuzzy-finder-view.coffee
@@ -169,6 +169,9 @@ class FuzzyFinderView extends SelectListView
 
     trimmedPath is '' and colon isnt -1
 
+  setFilterQuery: (query) ->
+    @filterEditorView.setText(query)
+
   getFilterQuery: ->
     query = super
     colon = query.indexOf(':')

--- a/lib/git-status-view.coffee
+++ b/lib/git-status-view.coffee
@@ -4,11 +4,12 @@ FuzzyFinderView = require './fuzzy-finder-view'
 
 module.exports =
 class GitStatusView extends FuzzyFinderView
-  toggle: ->
+  toggle: (query) ->
     if @panel?.isVisible()
       @cancel()
     else if atom.project.getRepositories().some((repo) -> repo?)
       @populate()
+      @setFilterQuery(query) if query?
       @show()
 
   getEmptyMessage: (itemCount) ->

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -15,12 +15,12 @@ module.exports =
     @active = true
 
     atom.commands.add 'atom-workspace',
-      'fuzzy-finder:toggle-file-finder': =>
-        @createProjectView().toggle()
-      'fuzzy-finder:toggle-buffer-finder': =>
-        @createBufferView().toggle()
-      'fuzzy-finder:toggle-git-status-finder': =>
-        @createGitStatusView().toggle()
+      'fuzzy-finder:toggle-file-finder': (event) =>
+        @createProjectView().toggle(event.detail)
+      'fuzzy-finder:toggle-buffer-finder': (event) =>
+        @createBufferView().toggle(event.detail)
+      'fuzzy-finder:toggle-git-status-finder': (event) =>
+        @createGitStatusView().toggle(event.detail)
 
     process.nextTick => @startLoadPathsTask()
 

--- a/lib/project-view.coffee
+++ b/lib/project-view.coffee
@@ -47,11 +47,12 @@ class ProjectView extends FuzzyFinderView
     @disposables.add atom.config.onDidChange 'core.excludeVcsIgnoredPaths', =>
       @reloadPaths = true
 
-  toggle: ->
+  toggle: (query) ->
     if @panel?.isVisible()
       @cancel()
     else
       @populate()
+      @setFilterQuery(query) if query?
       @show()
 
   getEmptyMessage: (itemCount) ->

--- a/spec/fuzzy-finder-spec.coffee
+++ b/spec/fuzzy-finder-spec.coffee
@@ -858,6 +858,20 @@ describe 'FuzzyFinder', ->
       expect(projectView.filterEditorView.getText()).toBe 'this should show up next time we open finder'
       expect(projectView.filterEditorView.getModel().getSelectedText()).toBe 'this should show up next time we open finder'
 
+  dispatchCommandWithQuery = (command, query) ->
+    atom.commands.dispatch(workspaceElement, "fuzzy-finder:#{command}", query)
+
+  describe "accept query when toggling", ->
+    it "accepts query when toggling file-finder", ->
+      dispatchCommandWithQuery('toggle-file-finder', 'this should be my file search query right now')
+      expect(atom.workspace.panelForItem(projectView).isVisible()).toBe true
+      expect(projectView.filterEditorView.getText()).toBe 'this should be my file search query right now'
+
+    it "accepts query when toggling buffer-finder", ->
+      dispatchCommandWithQuery('toggle-buffer-finder', 'this should be my buffer search query right now')
+      expect(atom.workspace.panelForItem(bufferView).isVisible()).toBe true
+      expect(bufferView.filterEditorView.getText()).toBe 'this should be my buffer search query right now'
+
   describe "Git integration", ->
     [projectPath, gitRepository, gitDirectory] = []
 
@@ -896,6 +910,11 @@ describe 'FuzzyFinder', ->
 
         expect(gitStatusView.find('.status.status-modified').length).toBe 1
         expect(gitStatusView.find('.status.status-added').length).toBe 1
+
+      it "accepts query when toggling git-status-finder", ->
+        dispatchCommandWithQuery('toggle-git-status-finder', 'this should be my git-status search query right now')
+        expect(atom.workspace.panelForItem(gitStatusView).isVisible()).toBe true
+        expect(gitStatusView.filterEditorView.getText()).toBe 'this should be my git-status search query right now'
 
     describe "status decorations", ->
       [originalText, originalPath, editor, newPath] = []


### PR DESCRIPTION
Please consider this functionality, if my implementation is poor I'm happy to hear suggestions.

I've added an optional parameter to the fuzzy-finder:toggle-file-finder, buffer-finder, and git-status-finder commands. A user can raise an event with the event.detail set to a search query string. For example the following javascript can be run directly from the debugger console.

`atom.commands.dispatch(atom.views.getView(atom.workspace), "fuzzy-finder:toggle-file-finder", "my/custom/filepath.c")`

This allows other packages / custom scripts to access more of the fuzzy-finder functionality from the outside. I've used this SPECIFICALLY to automatically fuzzy-find a C/C++ header file from the cursor position located on #include "si/unittest.h" ... in this case si/unittest.h is a relative path and a valid match may exist in several locations in the project, therefore fuzzy-find is perfect for the occasion, but there is no need to reinvent the wheel when we already have a great fuzzy-finder package to draw from.

All pre-existing unittests pass. I have added 3 additional tests to test passing in the optional query to the file-finder, buffer-finder, and git-status-finder.

Thanks,
Kyle
