### PR TITLE
Feature Save Search Across fuzzy finder menus

### DIFF
--- a/lib/fuzzy-finder-view.coffee
+++ b/lib/fuzzy-finder-view.coffee
@@ -238,6 +238,12 @@ class FuzzyFinderView extends SelectListView
   setItems: (filePaths) ->
     super(@projectRelativePathsForFilePaths(filePaths))
 
+  setText: (searchText)->
+    @filterEditorView.setText(searchText)
+
+  getText: ()->
+    @filterEditorView.getText()
+
   projectRelativePathsForFilePaths: (filePaths) ->
     # Don't regenerate project relative paths unless the file paths have changed
     if filePaths isnt @filePaths

--- a/lib/fuzzy-finder-view.coffee
+++ b/lib/fuzzy-finder-view.coffee
@@ -238,10 +238,10 @@ class FuzzyFinderView extends SelectListView
   setItems: (filePaths) ->
     super(@projectRelativePathsForFilePaths(filePaths))
 
-  setText: (searchText)->
+  setText: (searchText) ->
     @filterEditorView.setText(searchText)
 
-  getText: ()->
+  getText: ->
     @filterEditorView.getText()
 
   projectRelativePathsForFilePaths: (filePaths) ->

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -16,6 +16,10 @@ module.exports =
       type: 'boolean'
       default: false
       description: 'Use an alternative scoring approach which prefers run of consecutive characters, acronyms and start of words. (Experimental)'
+    preserveSearchBetweenViews:
+      type: 'boolean'
+      default: false
+      description: 'Remember the typed query when switching between different file finder, buffer finder and git status finder.'
 
   activate: (state) ->
     @active = true
@@ -95,6 +99,7 @@ module.exports =
 
 
   setTextToPrevious: (fuzzyFinderView)->
+    return unless atom.config.get('fuzzy-finder.preserveSearchBetweenViews')
     previous = @previous
     @previous = fuzzyFinderView
     return unless previous and previous isnt @previous

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -64,18 +64,21 @@ module.exports =
       ProjectView  = require './project-view'
       @projectView = new ProjectView(@projectPaths)
       @projectPaths = null
+    @setTextToPrevious(@projectView)
     @projectView
 
   createGitStatusView: ->
     unless @gitStatusView?
       GitStatusView  = require './git-status-view'
       @gitStatusView = new GitStatusView()
+    @setTextToPrevious(@gitStatusView)
     @gitStatusView
 
   createBufferView: ->
     unless @bufferView?
       BufferView = require './buffer-view'
       @bufferView = new BufferView()
+    @setTextToPrevious(@bufferView)
     @bufferView
 
   startLoadPathsTask: ->
@@ -89,6 +92,13 @@ module.exports =
     @projectPathsSubscription = atom.project.onDidChangePaths =>
       @projectPaths = null
       @stopLoadPathsTask()
+
+
+  setTextToPrevious: (fuzzyFinderView)->
+    previous = @previous
+    @previous = fuzzyFinderView
+    return unless previous and previous isnt @previous
+    fuzzyFinderView.setText(previous.getText())
 
   stopLoadPathsTask: ->
     @projectPathsSubscription?.dispose()

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -98,7 +98,7 @@ module.exports =
       @stopLoadPathsTask()
 
 
-  setTextToPrevious: (fuzzyFinderView)->
+  setTextToPrevious: (fuzzyFinderView) ->
     return unless atom.config.get('fuzzy-finder.preserveSearchBetweenViews')
     previous = @previous
     @previous = fuzzyFinderView

--- a/spec/fuzzy-finder-spec.coffee
+++ b/spec/fuzzy-finder-spec.coffee
@@ -870,6 +870,28 @@ describe 'FuzzyFinder', ->
       expect(projectView.filterEditorView.getText()).toBe 'this should show up next time we open finder'
       expect(projectView.filterEditorView.getModel().getSelectedText()).toBe 'this should show up next time we open finder'
 
+  describe "preserve search between finder views", ->
+    it "should preserve search between views", ->
+      dispatchCommand('toggle-file-finder')
+      expect(atom.workspace.panelForItem(projectView).isVisible()).toBe true
+      projectView.filterEditorView.getModel().setText("i'll be back")
+
+      dispatchCommand('toggle-buffer-finder')
+      expect(atom.workspace.panelForItem(bufferView).isVisible()).toBe true
+
+      expect(atom.workspace.panelForItem(projectView).isVisible()).toBe false
+      expect(bufferView.filterEditorView.getText()).toBe "i'll be back"
+    it "shouldn't preserve search if previous view is not being shown", ->
+      dispatchCommand('toggle-file-finder')
+      expect(atom.workspace.panelForItem(projectView).isVisible()).toBe true
+      projectView.filterEditorView.getModel().setText("i'll be back")
+      dispatchCommand('toggle-file-finder')
+      expect(atom.workspace.panelForItem(projectView).isVisible()).toBe false
+
+      dispatchCommand('toggle-buffer-finder')
+      expect(atom.workspace.panelForItem(bufferView).isVisible()).toBe true
+      expect(bufferView.filterEditorView.getText()).toBe ""
+
   describe "Git integration", ->
     [projectPath, gitRepository, gitDirectory] = []
 

--- a/spec/fuzzy-finder-spec.coffee
+++ b/spec/fuzzy-finder-spec.coffee
@@ -871,26 +871,42 @@ describe 'FuzzyFinder', ->
       expect(projectView.filterEditorView.getModel().getSelectedText()).toBe 'this should show up next time we open finder'
 
   describe "preserve search between finder views", ->
-    it "should preserve search between views", ->
+    it "shouldn't preserve search by default", ->
       dispatchCommand('toggle-file-finder')
       expect(atom.workspace.panelForItem(projectView).isVisible()).toBe true
-      projectView.filterEditorView.getModel().setText("i'll be back")
+      projectView.filterEditorView.getModel().setText("this shouldn't show up when we open git finder")
 
       dispatchCommand('toggle-buffer-finder')
       expect(atom.workspace.panelForItem(bufferView).isVisible()).toBe true
 
       expect(atom.workspace.panelForItem(projectView).isVisible()).toBe false
-      expect(bufferView.filterEditorView.getText()).toBe "i'll be back"
-    it "shouldn't preserve search if previous view is not being shown", ->
-      dispatchCommand('toggle-file-finder')
-      expect(atom.workspace.panelForItem(projectView).isVisible()).toBe true
-      projectView.filterEditorView.getModel().setText("i'll be back")
-      dispatchCommand('toggle-file-finder')
-      expect(atom.workspace.panelForItem(projectView).isVisible()).toBe false
-
-      dispatchCommand('toggle-buffer-finder')
-      expect(atom.workspace.panelForItem(bufferView).isVisible()).toBe true
       expect(bufferView.filterEditorView.getText()).toBe ""
+      
+    describe 'with configuration set', ->
+      beforeEach ->
+        atom.config.set("fuzzy-finder.preserveSearchBetweenViews", true)
+
+      it "should preserve search between views", ->
+        dispatchCommand('toggle-file-finder')
+        expect(atom.workspace.panelForItem(projectView).isVisible()).toBe true
+        projectView.filterEditorView.getModel().setText("this should show up when we open git finder")
+
+        dispatchCommand('toggle-buffer-finder')
+        expect(atom.workspace.panelForItem(bufferView).isVisible()).toBe true
+
+        expect(atom.workspace.panelForItem(projectView).isVisible()).toBe false
+        expect(bufferView.filterEditorView.getText()).toBe "this should show up when we open git finder"
+
+      it "shouldn't preserve search if previous view is not being shown", ->
+        dispatchCommand('toggle-file-finder')
+        expect(atom.workspace.panelForItem(projectView).isVisible()).toBe true
+        projectView.filterEditorView.getModel().setText "this shouldn't show up when we close file finder and open git finder"
+        dispatchCommand('toggle-file-finder')
+        expect(atom.workspace.panelForItem(projectView).isVisible()).toBe false
+
+        dispatchCommand('toggle-buffer-finder')
+        expect(atom.workspace.panelForItem(bufferView).isVisible()).toBe true
+        expect(bufferView.filterEditorView.getText()).toBe ""
 
   describe "Git integration", ->
     [projectPath, gitRepository, gitDirectory] = []


### PR DESCRIPTION
Keeps the search query when switching between File Finder, Buffer Finder and Git Status Finder.

I find it helpful when I'm using the 'File Finder', I remember that the file I'm looking for has been changed so I switch to 'Git Status Finder' to narrow the search but I have to start the query all over.

Added as a configuration option.

![obligatory-gif-1](https://cloud.githubusercontent.com/assets/6118156/10774660/8ce47074-7cfa-11e5-8799-4fd9a7f63d5a.gif)
![obligatory-gif-2](https://cloud.githubusercontent.com/assets/6118156/10774661/8ce4ec84-7cfa-11e5-9abd-d3ab812b212d.gif)
