### PR TITLE
Add down/up movement in fuzzy-finder list using tab/shift-tab

### DIFF
--- a/keymaps/fuzzy-finder.cson
+++ b/keymaps/fuzzy-finder.cson
@@ -18,3 +18,7 @@
 
 '.fuzzy-finder atom-text-editor[mini]':
   'shift-enter': 'fuzzy-finder:invert-confirm'
+  
+'.fuzzy-finder':
+  'tab': 'core:move-down'
+  'shift-tab': 'core:move-up'


### PR DESCRIPTION
I recently discovered this behaviour in the chrome address bar and find it incredibly usefull compared to using arrow of additional character