### PR TITLE
Use scandal to build the project file list

### DIFF
--- a/lib/load-paths-handler.coffee
+++ b/lib/load-paths-handler.coffee
@@ -1,107 +1,48 @@
 async = require 'async'
-fs = require 'fs'
 path = require 'path'
 _ = require 'underscore-plus'
-{GitRepository} = require 'atom'
-{Minimatch} = require 'minimatch'
+{PathSearcher, PathScanner, search} = require 'scandal'
 
-PathsChunkSize = 100
-
-emittedPaths = new Set
-
-class PathLoader
-  constructor: (@rootPath, ignoreVcsIgnores, @traverseSymlinkDirectories, @ignoredNames) ->
-    @paths = []
-    @realPathCache = {}
-    @repo = null
-    if ignoreVcsIgnores
-      repo = GitRepository.open(@rootPath, refreshOnWindowFocus: false)
-      @repo = repo if repo?.relativize(path.join(@rootPath, 'test')) is 'test'
-
-  load: (done) ->
-    @loadPath @rootPath, =>
-      @flushPaths()
-      @repo?.destroy()
-      done()
-
-  isIgnored: (loadedPath) ->
-    relativePath = path.relative(@rootPath, loadedPath)
-    if @repo?.isPathIgnored(relativePath)
-      true
-    else
-      for ignoredName in @ignoredNames
-        return true if ignoredName.match(relativePath)
-
-  pathLoaded: (loadedPath, done) ->
-    unless @isIgnored(loadedPath) or emittedPaths.has(loadedPath)
-      @paths.push(loadedPath)
-      emittedPaths.add(loadedPath)
-
-    if @paths.length is PathsChunkSize
-      @flushPaths()
-    done()
-
-  flushPaths: ->
-    emit('load-paths:paths-found', @paths)
-    @paths = []
-
-  loadPath: (pathToLoad, done) ->
-    return done() if @isIgnored(pathToLoad)
-    fs.lstat pathToLoad, (error, stats) =>
-      return done() if error?
-      if stats.isSymbolicLink()
-        @isInternalSymlink pathToLoad, (isInternal) =>
-          return done() if isInternal
-          fs.stat pathToLoad, (error, stats) =>
-            return done() if error?
-            if stats.isFile()
-              @pathLoaded(pathToLoad, done)
-            else if stats.isDirectory()
-              if @traverseSymlinkDirectories
-                @loadFolder(pathToLoad, done)
-              else
-                done()
-            else
-              done()
-      else if stats.isDirectory()
-        @loadFolder(pathToLoad, done)
-      else if stats.isFile()
-        @pathLoaded(pathToLoad, done)
-      else
-        done()
-
-  loadFolder: (folderPath, done) ->
-    fs.readdir folderPath, (error, children=[]) =>
-      async.each(
-        children,
-        (childName, next) =>
-          @loadPath(path.join(folderPath, childName), next)
-        done
-      )
-
-  isInternalSymlink: (pathToLoad, done) ->
-    fs.realpath pathToLoad, @realPathCache, (err, realPath) =>
-      if err
-        done(false)
-      else
-        done(realPath.search(@rootPath) is 0)
-
-module.exports = (rootPaths, followSymlinks, ignoreVcsIgnores, ignores=[]) ->
-  ignoredNames = []
-  for ignore in ignores when ignore
-    try
-      ignoredNames.push(new Minimatch(ignore, matchBase: true, dot: true))
-    catch error
-      console.warn "Error parsing ignore pattern (#{ignore}): #{error.message}"
+module.exports = (rootPaths, options={}) ->
+  pathsSearched = 0
+  PATHS_COUNTER_SEARCHED_CHUNK = 50
 
   async.each(
     rootPaths,
     (rootPath, next) ->
-      new PathLoader(
-        rootPath,
-        ignoreVcsIgnores,
-        followSymlinks,
-        ignoredNames
-      ).load(next)
+      options2 = _.extend {}, options,
+        inclusions: processPaths(rootPath, options.inclusions)
+        globalExclusions: processPaths(rootPath, options.globalExclusions)
+
+      scanner = new PathScanner(rootPath, options2)
+
+      paths = []
+
+      scanner.on 'path-found', (path) ->
+        paths.push path
+        pathsSearched++
+        if pathsSearched % PATHS_COUNTER_SEARCHED_CHUNK is 0
+          emit('load-paths:paths-found', paths)
+          paths = []
+      scanner.on 'finished-scanning', ->
+        emit('load-paths:paths-found', paths)
+        next()
+      scanner.scan()
+
     @async()
   )
+
+processPaths = (rootPath, paths) ->
+  return paths unless paths?.length > 0
+  rootPathBase = path.basename(rootPath)
+  results = []
+  for givenPath in paths
+    segments = givenPath.split(path.sep)
+    firstSegment = segments.shift()
+    results.push(givenPath)
+    if firstSegment is rootPathBase
+      if segments.length is 0
+        results.push(path.join("**", "*"))
+      else
+        results.push(path.join(segments...))
+  results

--- a/lib/path-loader.coffee
+++ b/lib/path-loader.coffee
@@ -4,18 +4,20 @@ module.exports =
   startTask: (callback) ->
     projectPaths = []
     taskPath = require.resolve('./load-paths-handler')
-    followSymlinks = atom.config.get 'core.followSymlinks'
+
     ignoredNames = atom.config.get('fuzzy-finder.ignoredNames') ? []
     ignoredNames = ignoredNames.concat(atom.config.get('core.ignoredNames') ? [])
-    ignoreVcsIgnores = atom.config.get('core.excludeVcsIgnoredPaths')
+
+    options =
+      excludeVcsIgnores: atom.config.get 'core.excludeVcsIgnoredPaths',
+      exclusions: ignoredNames,
+      follow: atom.config.get 'core.followSymlinks',
 
     task = Task.once(
       taskPath,
       atom.project.getPaths(),
-      followSymlinks,
-      ignoreVcsIgnores,
-      ignoredNames, ->
-        callback(projectPaths)
+      options,
+      -> callback(projectPaths)
     )
 
     task.on 'load-paths:paths-found', (paths) ->

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "fuzzaldrin-plus": "^0.1",
     "humanize-plus": "~1.4.2",
     "minimatch": "~0.3.0",
+    "scandal": "^2.2",
     "temp": "~0.8.1",
     "underscore-plus": "^1.0.0",
     "wrench": "^1.5"


### PR DESCRIPTION
Atom core has scandal, which is _all about_ building a list of files
in a fairly efficient manner, and thinking about VCS issues and
symbolic links and whatnot. Instead of reimplementing pieces of that,
just use it.

This has the nice side-effect of fixing issue #111, because scandal is
better at deciding which files should be ignored.