### PR TITLE
Make shift-down open the selected file in the background

### DIFF
--- a/keymaps/fuzzy-finder.cson
+++ b/keymaps/fuzzy-finder.cson
@@ -18,3 +18,4 @@
 
 '.fuzzy-finder atom-text-editor[mini]':
   'shift-enter': 'fuzzy-finder:invert-confirm'
+  'shift-down': 'fuzzy-finder:confirm-and-advance'


### PR DESCRIPTION
Prototype implementation of https://github.com/atom/fuzzy-finder/issues/70

Use shift-down to open the selected file in the background before advancing the list selection to the next item - useful for quickly opening multiple files from the finder.

This is almost certainly not a clean enough implementation and I have only ensured existing specs pass and not written additional ones. Hopefully it will let people play around with the functionality though and demonstrate its usefulness to be included in the package.
