### PR TITLE
Return project paths correctly if last-opened path is not in project

### DIFF
--- a/lib/project-view.coffee
+++ b/lib/project-view.coffee
@@ -96,6 +96,7 @@ class ProjectView extends FuzzyFinderView
             [entry] = data.splice(index, 1)
             data.unshift(entry)
             return data
+        data
 
     dataPromise
 

--- a/spec/fuzzy-finder-spec.coffee
+++ b/spec/fuzzy-finder-spec.coffee
@@ -134,7 +134,7 @@ describe 'FuzzyFinder', ->
           dispatchCommand('toggle-file-finder') # Show again
           expect(PathLoader.startTask.callCount).toBe 1
 
-        it "puts the last active path first", ->
+        it "puts the last opened path first", ->
           waitsForPromise -> atom.workspace.open 'sample.txt'
           waitsForPromise -> atom.workspace.open 'sample.js'
 
@@ -145,6 +145,14 @@ describe 'FuzzyFinder', ->
           runs ->
             expect(projectView.list.find("li:eq(0)").text()).toContain('sample.txt')
             expect(projectView.list.find("li:eq(1)").text()).toContain('sample.html')
+
+        it "displays paths correctly if the last-opened path is not part of the project (regression)", ->
+          waitsForPromise -> atom.workspace.open 'foo.txt'
+          waitsForPromise -> atom.workspace.open 'sample.js'
+
+          runs -> dispatchCommand('toggle-file-finder')
+
+          waitForPathsToDisplay(projectView)
 
         describe "symlinks on #darwin or #linux", ->
           [junkDirPath, junkFilePath] = []


### PR DESCRIPTION
![screen shot 2016-03-08 at 7 20 40 pm](https://cloud.githubusercontent.com/assets/1789/13623304/e056b64c-e562-11e5-9c6f-a33eeb9411e7.png)

The previous code wasn’t returning `data` correctly if the last opened path was not found in the list, leading to the behavior pictured above. Basically if you switched away from an editor that was outside the project to a new editor, than toggled the fuzzy-finder, you'd see that screenshot.

/cc @joshaber for awareness but with :heart:.