### PR TITLE
Initialize File Finder with the text selected in active editor

### DIFF
--- a/lib/fuzzy-finder-view.coffee
+++ b/lib/fuzzy-finder-view.coffee
@@ -39,7 +39,11 @@ class FuzzyFinderView extends SelectListView
 
   cancel: ->
     if atom.config.get('fuzzy-finder.preserveLastSearch')
-      lastSearch = @getFilterQuery()
+      if atom.config.get('fuzzy-finder.searchSelectedText') and @savedQuery?
+        lastSearch = @savedQuery
+        @savedQuery = null
+      else
+        lastSearch = @getFilterQuery()
       super
 
       @filterEditorView.setText(lastSearch)

--- a/lib/project-view.coffee
+++ b/lib/project-view.coffee
@@ -10,6 +10,7 @@ class ProjectView extends FuzzyFinderView
   paths: null
   reloadPaths: true
   reloadAfterFirstLoad: false
+  savedQuery: null
 
   initialize: (@paths) ->
     super
@@ -61,6 +62,11 @@ class ProjectView extends FuzzyFinderView
       super
 
   populate: ->
+    if atom.config.get('fuzzy-finder.searchSelectedText') and (activeTextEditor = atom.workspace.getActiveTextEditor())
+      selectedText = activeTextEditor.getSelectedText()
+      if selectedText.length
+        @savedQuery = @filterEditorView.getText()
+        @filterEditorView.setText(selectedText)
     @setItems(@paths) if @paths?
 
     if atom.project.getPaths().length is 0

--- a/package.json
+++ b/package.json
@@ -39,6 +39,11 @@
       "default": false,
       "description": "Remember the typed query when closing the fuzzy finder and use that as the starting query next time the fuzzy finder is opened."
     },
+    "searchSelectedText": {
+      "type": "boolean",
+      "default": false,
+      "description": "When fuzzy finder opens, initialize it with the text selected in the active tab."
+    },
     "useAlternateScoring": {
       "type": "boolean",
       "default": true,

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "searchSelectedText": {
       "type": "boolean",
       "default": false,
-      "description": "When fuzzy finder opens, initialize it with the text selected in the active tab."
+      "description": "When file finder opens, initialize it with the text selected in the active tab."
     },
     "useAlternateScoring": {
       "type": "boolean",


### PR DESCRIPTION
Often, in the code we have file paths of files to be included or fetched. Opening such files currently requires one to copy the path and then paste it in the file finder search box.

This PR enables the file finder to detect text that is already selected in the active editor and search for it automatically on opening, thus saving the user an extra copy-paste operation.

Enabled as a configuration option.

![settings1](https://cloud.githubusercontent.com/assets/9528856/13820217/55ab2c7e-ebc2-11e5-8cef-451508a27546.png)

This feature is available in WebStorm and was very handy. Had been missing it since I switched over from WebStorm to Atom.

Have been using it in Atom for 2 months now. Created the pull request today.

![fuzzy-finder-enhancement](https://cloud.githubusercontent.com/assets/9528856/13809617/98777b10-eb91-11e5-9be2-c182cdf2ac96.gif)
