### PR TITLE
Revert of 7346c18c3b9d73f09d0d000aa3617839d7c7263a

### DIFF
--- a/lib/helpers.coffee
+++ b/lib/helpers.coffee
@@ -4,5 +4,5 @@ module.exports =
   repositoryForPath: (filePath) ->
     for projectPath, i in atom.project.getPaths()
       if filePath is projectPath or filePath.startsWith(projectPath + path.sep)
-        return atom.project.getRepositories()[i]?.async
+        return atom.project.getRepositories()[i]
     return null

--- a/lib/project-view.coffee
+++ b/lib/project-view.coffee
@@ -86,19 +86,17 @@ class ProjectView extends FuzzyFinderView
           pathsFound += paths.length
           @loadingBadge.text(humanize.intComma(pathsFound))
 
-  dataForFilePaths: ->
-    dataPromise = super
+  projectRelativePathsForFilePaths: ->
+    projectRelativePaths = super
 
     if lastOpenedPath = @getLastOpenedPath()
-      dataPromise = dataPromise.then (data) ->
-        for {filePath}, index in data
-          if filePath is lastOpenedPath
-            [entry] = data.splice(index, 1)
-            data.unshift(entry)
-            return data
-        data
+      for {filePath}, index in projectRelativePaths
+        if filePath is lastOpenedPath
+          [entry] = projectRelativePaths.splice(index, 1)
+          projectRelativePaths.unshift(entry)
+          break
 
-    dataPromise
+    projectRelativePaths
 
   getLastOpenedPath: ->
     activePath = atom.workspace.getActivePaneItem()?.getPath?()


### PR DESCRIPTION
:bug:  This commit reverts 7346c18c3b9d73f09d0d000aa3617839d7c7263a

Using async git status causes massive load times after the initial
project indexing in atom 1.7+ (does same in atom 1.8). Until a better
way for using async git status is found (and actually tested this time),
this commit should be reverted.