### PR TITLE
Catch ENOENT when reloading paths

### DIFF
--- a/lib/project-view.coffee
+++ b/lib/project-view.coffee
@@ -93,7 +93,7 @@ class ProjectView extends FuzzyFinderView
         @setLoading("Indexing project\u2026")
         @loadingBadge.text('0')
         pathsFound = 0
-        task.on 'load-paths:paths-found', (paths) =>
+        task?.on 'load-paths:paths-found', (paths) =>
           pathsFound += paths.length
           @loadingBadge.text(humanize.intComma(pathsFound))
 


### PR DESCRIPTION
This fixes #196 and its dupes - if a network drive goes away, we were crashing while trying to get a realpath for the project. This just catches ENOENT and shows the user an error message rather than raising an uncaught error - not a big behavior change, but catching is better than not catching, eh?

@atom/feedback do you feel this is sufficient to address that problem?