### PR TITLE
Don't ignore the whole project.

### DIFF
--- a/lib/load-paths-handler.coffee
+++ b/lib/load-paths-handler.coffee
@@ -46,7 +46,7 @@ class PathLoader
     @paths = []
 
   loadPath: (pathToLoad, done) ->
-    return done() if @isIgnored(pathToLoad)
+    return done() if @isIgnored(pathToLoad) and pathToLoad isnt @rootPath
     fs.lstat pathToLoad, (error, stats) =>
       return done() if error?
       if stats.isSymbolicLink()

--- a/lib/load-paths-handler.coffee
+++ b/lib/load-paths-handler.coffee
@@ -19,7 +19,7 @@ class PathLoader
       @repo = repo if repo?.relativize(path.join(@rootPath, 'test')) is 'test'
 
   load: (done) ->
-    @loadPath @rootPath, =>
+    @loadPath @rootPath, true, =>
       @flushPaths()
       @repo?.destroy()
       done()
@@ -45,8 +45,8 @@ class PathLoader
     emit('load-paths:paths-found', @paths)
     @paths = []
 
-  loadPath: (pathToLoad, done) ->
-    return done() if @isIgnored(pathToLoad) and pathToLoad isnt @rootPath
+  loadPath: (pathToLoad, root, done) ->
+    return done() if @isIgnored(pathToLoad) and not root
     fs.lstat pathToLoad, (error, stats) =>
       return done() if error?
       if stats.isSymbolicLink()
@@ -75,7 +75,7 @@ class PathLoader
       async.each(
         children,
         (childName, next) =>
-          @loadPath(path.join(folderPath, childName), next)
+          @loadPath(path.join(folderPath, childName), false, next)
         done
       )
 


### PR DESCRIPTION
Fixes https://github.com/atom/fuzzy-finder/issues/111.

If the repository was embedded in another repository, then the inner repository itself could be ignored which meant we wouldn’t index anything.

This _might_ be less than ideal in that project roots which were previously entirely ignored now won’t be. But I gotta think that if you opened a project root, you don’t want the whole project ignored.