### PR TITLE
Declare calling context for icon-service providers

### DIFF
--- a/lib/fuzzy-finder-view.coffee
+++ b/lib/fuzzy-finder-view.coffee
@@ -105,7 +105,7 @@ class FuzzyFinderView extends SelectListView
           else if repo.isStatusModified(status)
             @div class: 'status status-modified icon icon-diff-modified'
 
-        typeClass = FileIcons.getService().iconClassForPath(filePath) or []
+        typeClass = FileIcons.getService().iconClassForPath(filePath, 'fuzzy-finder') or []
         unless Array.isArray typeClass
           typeClass = typeClass?.toString().split(/\s+/g)
 


### PR DESCRIPTION
Full explanation can be found here: atom/tabs#359.

This is essentially just a housekeeping PR to ensure all packages consuming this service behave consistently with each other. Nothing new is being added functionality-wise.

/cc @as-cii