### PR TITLE
Add service provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,33 @@ This package uses both the `core.ignoredNames` and `fuzzy-finder.ignoredNames` c
 This package also will also not show Git ignored files when the `core.excludeVcsIgnoredPaths` is enabled.
 
 ![](https://f.cloud.github.com/assets/671378/2241456/100db6b8-9cd3-11e3-9b3a-569c6b50cc60.png)
+
+## API
+
+This package provides a service that allows you to trigger **Fuzzy Finder** from other Atom packages.
+
+### Consume service
+
+#### package.json
+```json
+{
+  "consumedServices": {
+    "atom.fuzzy-finder": {
+      "versions": {
+        "1.0.0": "consumeFuzzyFinder"
+      }
+    }
+  }
+}
+```
+
+#### Your package main module
+```js
+consumeFuzzyFinder(fuzzyFinder) {
+  this.myPackage.fuzzyFinder = fuzzyFinder;
+}
+```
+
+### Service methods
+
+- `toggleWithQuery(query)` - sets filter to `query` and triggers **Fuzzy Finder** pane.

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -40,6 +40,9 @@ module.exports =
     new Disposable ->
       FileIcons.resetService()
 
+  provideFuzzyFinder: ->
+    toggleWithQuery: @createProjectView().toggleWithQuery.bind(@projectView)
+
   serialize: ->
     paths = {}
     for editor in atom.workspace.getTextEditors()

--- a/lib/project-view.js
+++ b/lib/project-view.js
@@ -54,6 +54,11 @@ export default class ProjectView extends FuzzyFinderView {
     }
   }
 
+  async toggleWithQuery (query) {
+    this.selectListView.refs.queryEditor.insertText(query)
+    await this.toggle()
+  }
+
   async populate () {
     if (atom.project.getPaths().length === 0) {
       await this.setItems([])

--- a/package.json
+++ b/package.json
@@ -30,6 +30,14 @@
       }
     }
   },
+  "providedServices": {
+    "atom.fuzzy-finder": {
+      "description": "fuzzy-finder",
+      "versions": {
+        "1.0.0": "provideFuzzyFinder"
+      }
+    }
+  },
   "configSchema": {
     "ignoredNames": {
       "type": "array",

--- a/spec/fuzzy-finder-spec.coffee
+++ b/spec/fuzzy-finder-spec.coffee
@@ -26,7 +26,7 @@ getOrScheduleUpdatePromise = ->
 
 describe 'FuzzyFinder', ->
   [rootDir1, rootDir2] = []
-  [fuzzyFinder, projectView, bufferView, gitStatusView, workspaceElement, fixturesPath] = []
+  [fuzzyFinder, projectView, bufferView, gitStatusView, service, workspaceElement, fixturesPath] = []
 
   beforeEach ->
     rootDir1 = fs.realpathSync(temp.mkdirSync('root-dir1'))
@@ -59,6 +59,7 @@ describe 'FuzzyFinder', ->
         projectView = fuzzyFinder.createProjectView()
         bufferView = fuzzyFinder.createBufferView()
         gitStatusView = fuzzyFinder.createGitStatusView()
+        service = fuzzyFinder.provideFuzzyFinder()
 
   dispatchCommand = (command) ->
     atom.commands.dispatch(workspaceElement, "fuzzy-finder:#{command}")
@@ -1099,13 +1100,14 @@ describe 'FuzzyFinder', ->
 
     it "preserves last search when the config is set", ->
       atom.config.set("fuzzy-finder.preserveLastSearch", true)
+      query = 'this should show up next time we open finder'
 
       waitsForPromise ->
         projectView.toggle()
 
       runs ->
         expect(atom.workspace.panelForItem(projectView).isVisible()).toBe true
-        projectView.selectListView.refs.queryEditor.insertText('this should show up next time we open finder')
+        projectView.selectListView.refs.queryEditor.insertText(query)
 
       waitsForPromise ->
         projectView.toggle()
@@ -1118,8 +1120,8 @@ describe 'FuzzyFinder', ->
 
       runs ->
         expect(atom.workspace.panelForItem(projectView).isVisible()).toBe true
-        expect(projectView.selectListView.getQuery()).toBe 'this should show up next time we open finder'
-        expect(projectView.selectListView.refs.queryEditor.getSelectedText()).toBe 'this should show up next time we open finder'
+        expect(projectView.selectListView.getQuery()).toBe query
+        expect(projectView.selectListView.refs.queryEditor.getSelectedText()).toBe query
 
   describe "file icons", ->
     fileIcons = new DefaultFileIcons
@@ -1297,3 +1299,14 @@ describe 'FuzzyFinder', ->
 
           runs ->
             expect(Array.from(projectView.element.querySelectorAll('li')).find((a) -> a.textContent.includes("file.txt"))).toBeDefined()
+
+  describe "toggleWithQuery service", ->
+    it "shows filter query provided by service", ->
+      query = 'this should show up'
+
+      waitsForPromise ->
+        service.toggleWithQuery(query)
+
+      runs ->
+        expect(atom.workspace.panelForItem(projectView).isVisible()).toBe true
+        expect(projectView.selectListView.getQuery()).toBe query


### PR DESCRIPTION
### Description of the Change

This PR adds service provider, so other packages can toggle Fuzzy Finder with custom query text. Also it replaces changes from PR #137 and PR #181 can be implemented as a package.

### Alternate Designs

1. As introduced in #137.
2. Everyone make their own implementation of Fuzzy Finder (like in [related-files](https://github.com/raviraa/related-files) or [related](https://github.com/nick125/related))

### Benefits

Packages can toggle Fuzzy Finder with custom query.

### Possible Drawbacks

No drawbacks

### Applicable Issues

No issues

### To Do
- [x] Add service provider
- [x] Add specs
- [x] Add docs