### PR TITLE
Don't wait for items to be updated before showing fuzzy finder

### DIFF
--- a/lib/buffer-view.js
+++ b/lib/buffer-view.js
@@ -24,9 +24,9 @@ export default class BufferView extends FuzzyFinderView {
       })
 
       const paths = Array.from(new Set(editors.map((editor) => editor.getPath())))
-      await this.setItems(paths)
       if (paths.length > 0) {
         this.show()
+        await this.setItems(paths)
       }
     }
   }

--- a/lib/git-status-view.js
+++ b/lib/git-status-view.js
@@ -23,8 +23,8 @@ export default class GitStatusView extends FuzzyFinderView {
 
         }
       }
-      await this.setItems(paths)
       this.show()
+      await this.setItems(paths)
     }
   }
 

--- a/lib/project-view.js
+++ b/lib/project-view.js
@@ -49,8 +49,8 @@ export default class ProjectView extends FuzzyFinderView {
     if (this.panel && this.panel.isVisible()) {
       this.cancel()
     } else {
-      await this.populate()
       this.show()
+      await this.populate()
     }
   }
 


### PR DESCRIPTION
Fixes #288.

Previously, we were waiting until the items had been populated before showing the fuzzy finder. However, this was causing an odd UX experience that made users accidentally type query characters into already opened buffers.

With this pull request, on toggle, we will show the fuzzy finder synchronously and only then request an animation frame where we populate the items.

/cc: @atom/maintainers 