### PR TITLE
Show matches correctly when `useAlternateScoring` is true

### DIFF
--- a/lib/fuzzy-finder-view.js
+++ b/lib/fuzzy-finder-view.js
@@ -56,7 +56,7 @@ export default class FuzzyFinderView {
       },
       elementForItem: ({filePath, projectRelativePath}) => {
         const filterQuery = this.selectListView.getFilterQuery()
-        const matches = this.alternateScoring ?
+        const matches = this.useAlternateScoring ?
           fuzzaldrinPlus.match(projectRelativePath, filterQuery) :
           fuzzaldrin.match(projectRelativePath, filterQuery)
 


### PR DESCRIPTION
Fixes #296.

/cc: @jeancroy @50Wliu 