### PR TITLE
Use git ls-files for loading paths when available.

### DIFF
--- a/lib/load-paths-handler.coffee
+++ b/lib/load-paths-handler.coffee
@@ -18,19 +18,19 @@ class PathLoader
   load: (done) ->
     repo = GitRepository.open(@rootPath, refreshOnWindowFocus: false)
     if repo?.relativize(path.join(@rootPath, 'test')) is 'test'
-      args = ['ls-files', '-c', '-o', '-z']
+      args = ['ls-files', '--cached', '--others', '-z']
       if @ignoreVcsIgnores
         args.push('--exclude-standard')
       for ignoredName in @ignoredNames
-        args.push("-x")
+        args.push('--exclude')
         args.push(ignoredName.pattern)
-      output = ""
+      output = ''
       proc = GitProcess.spawn(args, @rootPath)
       proc.stdout.on 'data', (chunk) ->
-        files = (output + chunk).split("\0")
+        files = (output + chunk).split('\0')
         output = files.pop()
         emit('load-paths:paths-found', files)
-      proc.on "close", (code) ->
+      proc.on 'close', (code) ->
         repo?.destroy()
         done()
     else

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "async": "0.2.6",
     "atom-select-list": "^0.1.0",
-    "dugite": "^1.30.0",
+    "dugite": "^1.35.0",
     "fs-plus": "^3.0.0",
     "fuzzaldrin": "^2.0",
     "fuzzaldrin-plus": "^0.4.1",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "dependencies": {
     "async": "0.2.6",
     "atom-select-list": "^0.1.0",
+    "dugite": "^1.30.0",
     "fs-plus": "^3.0.0",
     "fuzzaldrin": "^2.0",
     "fuzzaldrin-plus": "^0.4.1",


### PR DESCRIPTION
### Description of the Change

Leverage git to index a git-controlled project quickly by using git-ls-files where appropriate

#### Background ####

Walking though a large codebase with node fs is very slow. Gecko has almost 200k files, and it takes 17 seconds on a fast machine. The project is constantly being reindexed after each editor focus. There needs to be a better way.

#### Solution ####

Allow a native binary to walk the tree. A simple `find` or `git ls-files` is 40x faster than the current nodejs task. I used dugite here to wrap the git commands instead of using child_process because it is more portable and Atom already pulls it in as a dependency elsewhere.

_EDIT:_ This is faster because the non-git solution needs to query each file if it is ignored or not. This means reading, at least, `.gitignore` + `.git/info/exclude` on each traversed node.

### Alternate Designs

1. `find` on POSIX systems performs just as well, I decided to go with `git-ls-files` because it is more portable, and should be available on Windows, and because it has a simple flag for excluding VCS ignored files.
1. Use a node, `libgit2` based, library.`git-utils` doesn't expose an API that would allow this. I tried replicating git-ls-files with `nodegit` to see if it is possible, and it is 4x slower. So I think the git command line solution is the best.
1. Use `child_process.spawn`. This is twice as fast as this patch, because it would allow streaming the stdout. `dugite` currently does not allow that and needs a fixed buffer. I went with `dugite` because it seemed the most portable, even though it is pretty certain Atom will have access to git in its PATH.

### Benefits

A 40x speedup.
Time to index Gecko before patch: 16.5s.
After patch: 0.4s

### Possible Drawbacks

Following symlink subdirs is broken in this solution.

### Applicable Issues

What does this mean??