### PR TITLE
Support :row:column in fuzzy-finder-view

### DIFF
--- a/lib/fuzzy-finder-view.js
+++ b/lib/fuzzy-finder-view.js
@@ -44,7 +44,7 @@ export default class FuzzyFinderView {
           this.previousQueryWasLineJump = true
           this.selectListView.update({
             items: [],
-            emptyMessage: 'Jump to line in active editor'
+            emptyMessage: 'Enter a <row> or <row>:<column> to go there. Examples: "3" for row 3 or "2:7" for row 2 and column 7'
           })
         } else if (this.previousQueryWasLineJump && !isLineJump){
           this.previousQueryWasLineJump = false
@@ -177,18 +177,18 @@ export default class FuzzyFinderView {
 
   confirm ({filePath}={}, openOptions) {
     if (atom.workspace.getActiveTextEditor() && this.isQueryALineJump()) {
-      const lineNumber = this.getLineNumber()
+      const position = this.getPosition()
       this.cancel()
-      this.moveToLine(lineNumber)
+      this.moveTo(position)
     } else if (!filePath) {
       this.cancel()
     } else if (fs.isDirectorySync(filePath)) {
       this.selectListView.update({errorMessage: 'Selected path is a directory'})
       setTimeout(() => { this.selectListView.update({errorMessage: null}) }, 2000)
     } else {
-      const lineNumber = this.getLineNumber()
+      const position = this.getPosition()
       this.cancel()
-      this.openPath(filePath, lineNumber, openOptions)
+      this.openPath(filePath, position, openOptions)
     }
   }
 
@@ -213,46 +213,48 @@ export default class FuzzyFinderView {
     }
   }
 
-  async openPath (filePath, lineNumber, openOptions) {
+  async openPath (filePath, position, openOptions) {
     if (filePath) {
       await atom.workspace.open(filePath, openOptions)
-      this.moveToLine(lineNumber)
+      this.moveTo(position)
     }
   }
 
-  moveToLine (lineNumber = -1) {
-    if (lineNumber < 0) {
+  moveTo (position) {
+    if (position == null) {
       return
     }
 
     const editor = atom.workspace.getActiveTextEditor()
     if (editor) {
-      const position = new Point(lineNumber, 0)
       editor.scrollToBufferPosition(position, {center: true})
       editor.setCursorBufferPosition(position)
-      editor.moveToFirstCharacterOfLine()
+
+      if (position.column < 0) {
+        editor.moveToFirstCharacterOfLine()
+      }
     }
   }
 
   splitOpenPath (splitFn) {
     const {filePath} = this.selectListView.getSelectedItem() || {}
-    const lineNumber = this.getLineNumber()
+    const position = this.getPosition()
     const editor = atom.workspace.getActiveTextEditor()
     const activePane = atom.workspace.getActivePane()
 
     if (this.isQueryALineJump() && editor) {
       this.previouslyFocusedElement = null
       splitFn(activePane)({copyActiveItem: true})
-      this.moveToLine(lineNumber)
+      this.moveTo(position)
     } else if (!filePath) {
       return
     } else if (activePane) {
       this.previouslyFocusedElement = null
       splitFn(activePane)()
-      this.openPath(filePath, lineNumber)
+      this.openPath(filePath, position)
     } else {
       this.previouslyFocusedElement = null
-      this.openPath(filePath, lineNumber)
+      this.openPath(filePath, position)
     }
   }
 
@@ -263,14 +265,24 @@ export default class FuzzyFinderView {
     )
   }
 
-  getLineNumber () {
+  getPosition () {
     const query = this.selectListView.getQuery()
-    const colon = query.indexOf(':')
-    if (colon === -1) {
-      return -1
-    } else {
-      return parseInt(query.slice(colon + 1)) - 1
+    const parts = query.split(':')
+    if (parts.length === 1) {
+      return null
     }
+
+    const position = new Point(0, -1)
+
+    if (parts.length >= 2) {
+      position.row = parseInt(parts[1]) - 1
+    }
+
+    if (parts.length >= 3) {
+      position.column = parseInt(parts[2]) - 1
+    }
+
+    return position
   }
 
   setItems (filePaths) {

--- a/spec/fuzzy-finder-spec.coffee
+++ b/spec/fuzzy-finder-spec.coffee
@@ -923,11 +923,11 @@ describe 'FuzzyFinder', ->
           {filePath} = bufferView.selectListView.getSelectedItem()
           expect(atom.project.getDirectories()[0].resolve(filePath)).toBe editor1.getPath()
 
-          spyOn(bufferView, 'moveToLine').andCallThrough()
+          spyOn(bufferView, 'moveTo').andCallThrough()
           atom.commands.dispatch bufferView.element, 'core:confirm'
 
         waitsFor ->
-          bufferView.moveToLine.callCount > 0
+          bufferView.moveTo.callCount > 0
 
         runs ->
           expect(atom.workspace.getActiveTextEditor()).toBe editor1
@@ -1032,11 +1032,11 @@ describe 'FuzzyFinder', ->
 
         runs ->
           expect(bufferView.element.querySelectorAll('li').length).toBe 0
-          spyOn(bufferView, 'moveToLine').andCallThrough()
+          spyOn(bufferView, 'moveTo').andCallThrough()
           atom.commands.dispatch bufferView.element, 'core:confirm'
 
         waitsFor ->
-          bufferView.moveToLine.callCount > 0
+          bufferView.moveTo.callCount > 0
 
         runs ->
           expect(atom.workspace.getActiveTextEditor()).toBe editor1
@@ -1064,11 +1064,11 @@ describe 'FuzzyFinder', ->
 
         runs ->
           expect(bufferView.element.querySelectorAll('li').length).toBe 0
-          spyOn(bufferView, 'moveToLine').andCallThrough()
+          spyOn(bufferView, 'moveTo').andCallThrough()
           atom.commands.dispatch bufferView.element, 'pane:split-left'
 
         waitsFor ->
-          bufferView.moveToLine.callCount > 0
+          bufferView.moveTo.callCount > 0
 
         runs ->
           expect(atom.workspace.getActiveTextEditor()).not.toBe editor1


### PR DESCRIPTION
### Description of the Change

Add support for a second colon to indicate the column to jump to.

For instance: `sample.js:4:10`

### Alternate Designs

None that I can think of.

### Benefits

We could bind the `go-to-line:toggle` command to this package and insert a `:`. This would remove a package from needing to exist clearing up a touch of maintenance burden.

### Possible Drawbacks

None that I can think of.

### Applicable Issues

None.
