### PR TITLE
Track visited inodes in load-paths-handler to prevent looping

### DIFF
--- a/lib/load-paths-handler.js
+++ b/lib/load-paths-handler.js
@@ -14,7 +14,7 @@ class PathLoader {
     this.traverseSymlinkDirectories = traverseSymlinkDirectories
     this.ignoredNames = ignoredNames
     this.paths = []
-    this.realPathCache = {}
+    this.inodes = new Set()
     this.repo = null
     if (ignoreVcsIgnores) {
       const repo = GitRepository.open(this.rootPath, {refreshOnWindowFocus: false})
@@ -66,29 +66,35 @@ class PathLoader {
     fs.lstat(pathToLoad, (error, stats) => {
       if (error != null) { return done() }
       if (stats.isSymbolicLink()) {
-        this.isInternalSymlink(pathToLoad, (isInternal) => {
-          if (isInternal) return done()
-          fs.stat(pathToLoad, (error, stats) => {
-            if (error != null) return done()
-            if (stats.isFile()) {
-              this.pathLoaded(pathToLoad, done)
-            } else if (stats.isDirectory()) {
-              if (this.traverseSymlinkDirectories) {
-                this.loadFolder(pathToLoad, done)
-              } else {
-                done()
-              }
+        fs.stat(pathToLoad, (error, stats) => {
+          if (error != null) return done()
+          if (this.inodes.has(stats.ino)) {
+            return done()
+          } else {
+            this.inodes.add(stats.ino)
+          }
+
+          if (stats.isFile()) {
+            this.pathLoaded(pathToLoad, done)
+          } else if (stats.isDirectory()) {
+            if (this.traverseSymlinkDirectories) {
+              this.loadFolder(pathToLoad, done)
             } else {
               done()
             }
-          })
+          } else {
+            done()
+          }
         })
-      } else if (stats.isDirectory()) {
-        this.loadFolder(pathToLoad, done)
-      } else if (stats.isFile()) {
-        this.pathLoaded(pathToLoad, done)
       } else {
-        done()
+        this.inodes.add(stats.ino)
+        if (stats.isDirectory()) {
+          this.loadFolder(pathToLoad, done)
+        } else if (stats.isFile()) {
+          this.pathLoaded(pathToLoad, done)
+        } else {
+          done()
+        }
       }
     })
   }
@@ -102,16 +108,6 @@ class PathLoader {
         },
         done
       )
-    })
-  }
-
-  isInternalSymlink (pathToLoad, done) {
-    fs.realpath(pathToLoad, this.realPathCache, (err, realPath) => {
-      if (err) {
-        done(false)
-      } else {
-        done(realPath.search(this.rootPath) === 0)
-      }
     })
   }
 }

--- a/spec/fuzzy-finder-spec.js
+++ b/spec/fuzzy-finder-spec.js
@@ -32,8 +32,9 @@ describe('FuzzyFinder', () => {
   let fuzzyFinder, projectView, bufferView, gitStatusView, workspaceElement, fixturesPath
 
   beforeEach(() => {
-    rootDir1 = fs.realpathSync(temp.mkdirSync('root-dir1'))
-    rootDir2 = fs.realpathSync(temp.mkdirSync('root-dir2'))
+    const ancestorDir = fs.realpathSync(temp.mkdirSync('ancestor-dir'))
+    rootDir1 = path.join(ancestorDir, 'root-dir1')
+    rootDir2 = path.join(ancestorDir, 'root-dir2')
 
     fixturesPath = atom.project.getPaths()[0]
 
@@ -217,6 +218,7 @@ describe('FuzzyFinder', () => {
 
             fs.symlinkSync(atom.project.getDirectories()[0].resolve('sample.txt'), atom.project.getDirectories()[0].resolve('symlink-to-internal-file'))
             fs.symlinkSync(atom.project.getDirectories()[0].resolve('dir'), atom.project.getDirectories()[0].resolve('symlink-to-internal-dir'))
+            fs.symlinkSync(atom.project.getDirectories()[0].resolve('..'), atom.project.getDirectories()[0].resolve('symlink-to-project-dir-ancestor'))
 
             fs.unlinkSync(brokenFilePath)
           })


### PR DESCRIPTION
Fixes #329

This replaces the existing logic which attempted to detect "internal symlinks". We simply keep a set of every inode number we have visited and make sure we don't visit the same node twice when traversing through symbolic links.