### PR TITLE
Keep existing selection after reindexing

### DIFF
--- a/lib/fuzzy-finder-view.js
+++ b/lib/fuzzy-finder-view.js
@@ -292,12 +292,25 @@ export default class FuzzyFinderView {
     }
   }
 
-  setItems (filePaths) {
+  async setItems (filePaths) {
     this.items = this.projectRelativePathsForFilePaths(filePaths)
     if (this.isQueryALineJump()) {
       return this.selectListView.update({items: [], loadingMessage: null, loadingBadge: null})
     } else {
-      return this.selectListView.update({items: this.items, loadingMessage: null, loadingBadge: null})
+      let selectedItem = this.selectListView.getSelectedItem()
+      if (selectedItem) {
+        for (let item of this.items) {
+          if (item.filePath === selectedItem.filePath && item.projectRelativePath === selectedItem.projectRelativePath) {
+            selectedItem = item
+            break
+          }
+        }
+      }
+
+      await this.selectListView.update({items: this.items, loadingMessage: null, loadingBadge: null})
+      try {
+        this.selectListView.selectItem(selectedItem)
+      } catch (error) {} // The previously selected item isn't always guaranteed to exist after a reindex
     }
   }
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

After a reindex completes, all the items in the select list get regenerated.  If someone had a file selected, the refresh would cause the selection to jump back to the first element.  This PR fixes that by manually re-selecting the previous file after the reindex completes.

### Alternate Designs

I hope there's an alternate design; this one didn't come out that pretty.

### Benefits

Selection will not unexpectedly change after a reindex completes.

### Possible Drawbacks

The for loop I added creates some delay, especially for larger projects since it loops through every single file.

### Applicable Issues

Fixes #210

/cc @Ben3eeE