### PR TITLE
Validate line numbers before jumping

### DIFF
--- a/lib/fuzzy-finder-view.js
+++ b/lib/fuzzy-finder-view.js
@@ -43,17 +43,26 @@ class FuzzyFinderView {
           this.iconDisposables = null
         }
         const isLineJump = this.isQueryALineJump()
-        if (!this.previousQueryWasLineJump && isLineJump) {
+        if (isLineJump && /[^\d]/.test(this.selectListView.getQuery().substr(1))) {
           this.previousQueryWasLineJump = true
           this.selectListView.update({
             items: [],
-            emptyMessage: 'Jump to line in active editor'
+            emptyMessage: null,
+            errorMessage: 'Invalid line number'
+          })
+        } else if (!this.previousQueryWasLineJump && isLineJump) {
+          this.previousQueryWasLineJump = true
+          this.selectListView.update({
+            items: [],
+            emptyMessage: 'Jump to line in active editor',
+            errorMessage: null
           })
         } else if (this.previousQueryWasLineJump && !isLineJump) {
           this.previousQueryWasLineJump = false
           this.selectListView.update({
             items: this.items,
-            emptyMessage: this.getEmptyMessage()
+            emptyMessage: this.getEmptyMessage(),
+            errorMessage: null
           })
         }
       },
@@ -239,16 +248,14 @@ class FuzzyFinderView {
   }
 
   moveToLine (lineNumber = -1) {
-    if (lineNumber < 0) {
-      return
-    }
-
-    const editor = atom.workspace.getActiveTextEditor()
-    if (editor) {
-      const position = new Point(lineNumber, 0)
-      editor.scrollToBufferPosition(position, {center: true})
-      editor.setCursorBufferPosition(position)
-      editor.moveToFirstCharacterOfLine()
+    if (lineNumber >= 0) { // account for NaNs
+      const editor = atom.workspace.getActiveTextEditor()
+      if (editor) {
+        const position = new Point(lineNumber, 0)
+        editor.scrollToBufferPosition(position, {center: true})
+        editor.setCursorBufferPosition(position)
+        editor.moveToFirstCharacterOfLine()
+      }
     }
   }
 

--- a/lib/fuzzy-finder-view.js
+++ b/lib/fuzzy-finder-view.js
@@ -43,7 +43,7 @@ class FuzzyFinderView {
           this.iconDisposables = null
         }
         const isLineJump = this.isQueryALineJump()
-        if (isLineJump && /[^\d]/.test(this.selectListView.getQuery().substr(1))) {
+        if (isLineJump && /\D/.test(this.selectListView.getQuery().substr(1))) {
           this.previousQueryWasLineJump = true
           this.selectListView.update({
             items: [],


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Only attempt to jump to a specific line number if the text after the colon is a valid line number.  Otherwise, show an error if appropriate and just jump to the file but don't change the cursor position.

### Alternate Designs

None.

### Benefits

Line number validation and no more uncaught exceptions related to that.

### Possible Drawbacks

None?

### Applicable Issues

Fixes #308