### PR TITLE
Dispose of commands and callbacks when deactivating

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -1,11 +1,13 @@
-const {Disposable} = require('atom')
+const {CompositeDisposable, Disposable} = require('atom')
 const getIconServices = require('./get-icon-services')
 
 module.exports = {
   activate (state) {
     this.active = true
 
-    atom.commands.add('atom-workspace', {
+    this.disposables = new CompositeDisposable()
+
+    this.disposables.add(atom.commands.add('atom-workspace', {
       'fuzzy-finder:toggle-file-finder': () => {
         this.createProjectView().toggle()
       },
@@ -15,7 +17,7 @@ module.exports = {
       'fuzzy-finder:toggle-git-status-finder': () => {
         this.createGitStatusView().toggle()
       }
-    })
+    }))
 
     process.nextTick(() => this.startLoadPathsTask())
 
@@ -23,14 +25,16 @@ module.exports = {
       editor.lastOpened = state[editor.getPath()]
     }
 
-    atom.workspace.observePanes((pane) => {
-      pane.observeActiveItem((item) => {
+    this.disposables.add(atom.workspace.observePanes(pane => {
+      this.disposables.add(pane.observeActiveItem(item => {
         if (item != null) item.lastOpened = Date.now()
-      })
-    })
+      }))
+    }))
   },
 
   deactivate () {
+    this.disposables.dispose()
+
     if (this.projectView != null) {
       this.projectView.destroy()
       this.projectView = null


### PR DESCRIPTION
Doesn't leave commands hanging around after fuzzy-finder is deactivated, and also stops observing panes for changes.