### PR TITLE
Fix "Project is empty" issue when using Teletype

### DIFF
--- a/lib/project-view.js
+++ b/lib/project-view.js
@@ -58,7 +58,8 @@ class ProjectView extends FuzzyFinderView {
   }
 
   async populate () {
-    const remoteEditors = this.teletypeService ? await this.teletypeService.getRemoteEditors() : []
+    const remoteEditors = (this.teletypeService && await this.teletypeService.getRemoteEditors()) || []
+
     const remoteItems = remoteEditors.map((remoteEditor) => {
       return {
         uri: remoteEditor.uri,

--- a/spec/project-view-spec.js
+++ b/spec/project-view-spec.js
@@ -57,4 +57,18 @@ describe('ProjectView', () => {
       {uri: 'remote2-uri', filePath: 'remote2-path', label: '@user-2: remote2-path', ownerGitHubUsername: 'user-2'}
     ])
   })
+
+  it('gracefully defaults to empty list if teletype is unable to provide remote editors', async () => {
+    const projectView = new ProjectView()
+
+    atom.project.setPaths([])
+    projectView.setTeletypeService({
+      async getRemoteEditors () {
+        return null
+      }
+    })
+
+    await projectView.toggle()
+    expect(projectView.items).toEqual([])
+  })
 })


### PR DESCRIPTION
### Description of the Change

If teletype is installed and enabled, the file finder asks the teletype service for a list of remote editors:

https://github.com/atom/fuzzy-finder/blob/8c3c074f8dbff7a82b323c15af14889307dcf3b2/lib/project-view.js#L61

fuzzy-finder then iterates over the list of remote editors:

https://github.com/atom/fuzzy-finder/blob/8c3c074f8dbff7a82b323c15af14889307dcf3b2/lib/project-view.js#L62

However, it's [possible for `getRemoteEditors()` to return `null`](https://github.com/atom/teletype/blob/v0.10.0/lib/teletype-service.js#L12). When that happens, the file finder fails to show any _local_ files. Instead, it shows "Project is empty", and we see an error in the console:

![screen shot 2018-04-02 at 12 26 58 pm](https://user-images.githubusercontent.com/2988/38205055-28c74fdc-3673-11e8-9bf0-c190975b9cac.png)

This pull request teaches the fuzzy-finder to gracefully handle a null return value from `getRemoteEditors()`.

### Alternate Designs

We could change Teletype's `getRemoteEditors()` method to return an empty array instead of returning null. (I intend to open a pull request for that change soon.) However, Teletype is not presently bundled with Atom. If we only fix the issue in Teletype, people might not realize that they need to upgrade Teletype in order to fix this behavior in the fuzzy finder. Since fuzzy-finder is bundled with Atom, we can fix this issue in fuzzy-finder and guarantee that people get this fix when they upgrade Atom.

### Verification process

- [ ] Verify file finder shows local files when Teletype is enabled and `getRemoteEditors()` returns null
- [ ] Verify file finder shows local files and remote files when Teletype is enabled and `getRemoteEditors()` returns nonempty list of remote editors
- [ ] Verify file finder shows local files Teletype is disabled
- [ ] Verify file finder shows local files Teletype is not installed

Note: Because @annthurium first observed this issue with Teletype 0.10.0, I'll run through the verification process above with Teletype 0.10.0 and the current version (0.11.0).
