### PR TITLE
Fix flaky test re "toggling when the project has multiple paths" 🤞

### DIFF
--- a/spec/fuzzy-finder-spec.js
+++ b/spec/fuzzy-finder-spec.js
@@ -254,13 +254,13 @@ describe('FuzzyFinder', () => {
         describe('socket files on #darwin or #linux', () => {
           let socketServer, socketPath
 
-          beforeEach(() => {
+          beforeEach(async () => {
             socketServer = net.createServer(() => {})
             socketPath = path.join(rootDir1, 'some.sock')
-            waitsFor(done => socketServer.listen(socketPath, done))
+            await socketServer.listen(socketPath)
           })
 
-          afterEach(() => waitsFor(done => socketServer.close(done)))
+          afterEach(async () => await socketServer.close())
 
           it('ignores them', async () => {
             await projectView.toggle()


### PR DESCRIPTION
Prior to this change, I was able to reliably reproduce the failures described in  https://github.com/atom/atom/issues/17325 when running `apm test` locally with Atom 1.29.0-dev-3e4b386. After this change, the tests reliably pass for me. Hopefully this resolves the flakiness described in https://github.com/atom/atom/issues/17325. 😅

_Most_ of the tests in `spec/fuzzy-finder-spec.js` use `async/await`, but the flaky tests were using a _mix_ of `async/await` and `waitsFor`. This change updates the flaky tests to only use `async/await`.