### PR TITLE
prevent current editor from showing up first

### DIFF
--- a/lib/fuzzy-finder-view.js
+++ b/lib/fuzzy-finder-view.js
@@ -122,12 +122,12 @@ class FuzzyFinderView {
                 if (filtered.length > 1) {
                   const activePaneItem = atom.workspace.getActivePaneItem()
                   if (activePaneItem && activePaneItem.getPath && activePaneItem.getPath() === filtered[0].filePath) {
-                    const x = filtered[0];
-                    filtered[0] = filtered[1];
-                    filtered[1] = x;
+                    const x = filtered[0]
+                    filtered[0] = filtered[1]
+                    filtered[1] = x
                   }
                 }
-                return filtered;
+                return filtered
               }
 
               return items

--- a/lib/fuzzy-finder-view.js
+++ b/lib/fuzzy-finder-view.js
@@ -117,7 +117,20 @@ class FuzzyFinderView {
         if (this.useAlternateScoring) {
           this.selectListView.update({
             filter: (items, query) => {
-              return query ? fuzzaldrinPlus.filter(items, query, {key: 'label'}) : items
+              if (query) {
+                const filtered = fuzzaldrinPlus.filter(items, query, {key: 'label'})
+                if (filtered.length > 1) {
+                  const activePaneItem = atom.workspace.getActivePaneItem()
+                  if (activePaneItem && activePaneItem.getPath && activePaneItem.getPath() === filtered[0].filePath) {
+                    const x = filtered[0];
+                    filtered[0] = filtered[1];
+                    filtered[1] = x;
+                  }
+                }
+                return filtered;
+              }
+
+              return items
             }
           })
         } else {

--- a/spec/fuzzy-finder-spec.js
+++ b/spec/fuzzy-finder-spec.js
@@ -173,8 +173,8 @@ describe('FuzzyFinder', () => {
 
         describe('when the current open buffer is the first match', () => {
           it('switches the first two matches', async () => {
-            await atom.workspace.open(path.join(rootDir1, 'git', 'working-dir', 'file.txt'));
-            await atom.workspace.open(path.join(rootDir1, 'git', 'working-dir', 'a.txt'));
+            await atom.workspace.open(path.join(rootDir1, 'git', 'working-dir', 'file.txt'))
+            await atom.workspace.open(path.join(rootDir1, 'git', 'working-dir', 'a.txt'))
 
             await projectView.toggle()
             await waitForPathsToDisplay(projectView)

--- a/spec/fuzzy-finder-spec.js
+++ b/spec/fuzzy-finder-spec.js
@@ -171,6 +171,22 @@ describe('FuzzyFinder', () => {
           expect(projectView.element.querySelectorAll('li')[1].textContent).toContain('sample.html')
         })
 
+        describe('when the current open buffer is the first match', () => {
+          it('switches the first two matches', async () => {
+            await atom.workspace.open(path.join(rootDir1, 'git', 'working-dir', 'file.txt'));
+            await atom.workspace.open(path.join(rootDir1, 'git', 'working-dir', 'a.txt'));
+
+            await projectView.toggle()
+            await waitForPathsToDisplay(projectView)
+
+            projectView.selectListView.refs.queryEditor.setText('a.txt')
+            await getOrScheduleUpdatePromise()
+
+            expect(projectView.element.querySelectorAll('li')[0].textContent).toContain('sample.txt')
+            expect(projectView.element.querySelectorAll('li')[1].textContent).toContain('a.txt')
+          })
+        })
+
         it('displays paths correctly if the last-opened path is not part of the project (regression)', async () => {
           await atom.workspace.open('foo.txt')
           await atom.workspace.open('sample.js')


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

The current open editor can end up being the first result in fuzzy search. This change makes sure it isn't.

I have a project with HTML and JS files named the same but the file extension, e.g. `project-marking.html` and `project-marking.js`, and I often want to quickly open the other one using fuzzy finder. However, fuzzy finder puts the `.js` file first, so if I'm there, open fuzzy finder, type `projmar`, pressing enter would just take me where I already am.

I would like to open fuzzy finder, type `projmar`, press enter, and be in **the other file that I know matches**.

This PR is a quick hack, an RFC really, that implements this change. Every time we filter, it checks that if we have more than one match, the first one shouldn't be the current open buffer – if it is, it switches the first two matches.

### Alternate Designs

I suspect that we might be able to cache the current open buffer's path when opening the fuzzy finder, but I don't know enough about the code to quickly guess where would be appropriate.

Also, this kind of sorting decision might be moved to fuzzaldrin, with some kind of *value that shouldn't be put first* parameter, but I don't have the time right now to investigate.

### Benefits

This allows me quicker to change files with fuzzy finder.

### Possible Drawbacks

If somebody already has in their muscle memory that they open fuzzy finder, type a query, and do *down* and *enter*, this would potentially give them the wrong file. 

### Applicable Issues

None I could find.