### PR TITLE
Close tab from fuzzy-finder list view

### DIFF
--- a/keymaps/fuzzy-finder.cson
+++ b/keymaps/fuzzy-finder.cson
@@ -18,3 +18,4 @@
 
 '.fuzzy-finder atom-text-editor[mini]':
   'shift-enter': 'fuzzy-finder:invert-confirm'
+  'ctrl-w': 'fuzzy-finder:kill-tab'

--- a/lib/fuzzy-finder-view.js
+++ b/lib/fuzzy-finder-view.js
@@ -196,7 +196,7 @@ class FuzzyFinderView {
     this.previouslyFocusedElement = document.activeElement
     if (!this.panel) {
       this.panel = atom.workspace.addModalPanel({item: this})
-    }
+}
     this.panel.show()
     if (atom.config.get('fuzzy-finder.prefillFromSelection') === true) {
       this.prefillQueryFromSelection()
@@ -207,7 +207,7 @@ class FuzzyFinderView {
   hide () {
     if (this.panel) {
       this.panel.hide()
-    }
+  }
 
     if (this.previouslyFocusedElement) {
       this.previouslyFocusedElement.focus()
@@ -220,6 +220,49 @@ class FuzzyFinderView {
       await atom.workspace.open(uri, openOptions)
       this.moveToLine(lineNumber)
     }
+  }
+
+  async closeSelectedURI () {
+      const selectedItem = this.selectListView.getSelectedItem()
+      if(!selectedItem)
+      {
+          return
+      }
+
+      const editors = atom.workspace.getTextEditors()
+      const targetEditor = editors.filter(x=>x.buffer.file.path === selectedItem.uri)
+      if(targetEditor && targetEditor[0])
+      {
+        var canClose = await atom.workspace.getActivePane().destroyItem(targetEditor[0])
+
+        if(canClose)
+        {
+          const lastItem = this.selectListView.items[this.selectListView.items.length - 1];
+
+          if (selectedItem === lastItem)
+          {
+            this.selectListView.selectPrevious()
+          }
+          else
+          {
+            this.selectListView.selectNext()
+          }
+
+          const newSelection = this.selectListView.getSelectedItem()
+
+          this.selectListView.props.items = this.selectListView.props.items.filter(x => x != selectedItem)
+          this.selectListView.computeItems()
+
+          if(newSelection != selectedItem)
+          {
+            this.selectListView.selectItem(newSelection)
+          }
+          else
+          {
+              this.cancel()
+          }
+        }
+      }
   }
 
   moveToLine (lineNumber = -1) {

--- a/lib/fuzzy-finder-view.js
+++ b/lib/fuzzy-finder-view.js
@@ -196,7 +196,7 @@ class FuzzyFinderView {
     this.previouslyFocusedElement = document.activeElement
     if (!this.panel) {
       this.panel = atom.workspace.addModalPanel({item: this})
-}
+    }
     this.panel.show()
     if (atom.config.get('fuzzy-finder.prefillFromSelection') === true) {
       this.prefillQueryFromSelection()
@@ -207,7 +207,7 @@ class FuzzyFinderView {
   hide () {
     if (this.panel) {
       this.panel.hide()
-  }
+    }
 
     if (this.previouslyFocusedElement) {
       this.previouslyFocusedElement.focus()

--- a/lib/fuzzy-finder-view.js
+++ b/lib/fuzzy-finder-view.js
@@ -238,8 +238,7 @@ class FuzzyFinderView {
 
         if (selectedItem === lastItem) {
           this.selectListView.selectPrevious()
-        }
-        else {
+        } else {
           this.selectListView.selectNext()
         }
 
@@ -250,8 +249,7 @@ class FuzzyFinderView {
 
         if (newSelection !== selectedItem) {
           this.selectListView.selectItem(newSelection)
-        }
-        else {
+        } else {
           this.cancel()
         }
       }

--- a/lib/fuzzy-finder-view.js
+++ b/lib/fuzzy-finder-view.js
@@ -223,46 +223,39 @@ class FuzzyFinderView {
   }
 
   async closeSelectedURI () {
-      const selectedItem = this.selectListView.getSelectedItem()
-      if(!selectedItem)
-      {
-          return
-      }
+    const selectedItem = this.selectListView.getSelectedItem()
+    if (!selectedItem) {
+      return
+    }
 
-      const editors = atom.workspace.getTextEditors()
-      const targetEditor = editors.filter(x=>x.buffer.file.path === selectedItem.uri)
-      if(targetEditor && targetEditor[0])
-      {
-        var canClose = await atom.workspace.getActivePane().destroyItem(targetEditor[0])
+    const editors = atom.workspace.getTextEditors()
+    const targetEditor = editors.filter(x => x.buffer.file && x.buffer.file.path === selectedItem.uri)
+    if (targetEditor && targetEditor[0]) {
+      var canClose = await atom.workspace.getActivePane().destroyItem(targetEditor[0])
 
-        if(canClose)
-        {
-          const lastItem = this.selectListView.items[this.selectListView.items.length - 1];
+      if (canClose) {
+        const lastItem = this.selectListView.items[this.selectListView.items.length - 1]
 
-          if (selectedItem === lastItem)
-          {
-            this.selectListView.selectPrevious()
-          }
-          else
-          {
-            this.selectListView.selectNext()
-          }
+        if (selectedItem === lastItem) {
+          this.selectListView.selectPrevious()
+        }
+        else {
+          this.selectListView.selectNext()
+        }
 
-          const newSelection = this.selectListView.getSelectedItem()
+        const newSelection = this.selectListView.getSelectedItem()
 
-          this.selectListView.props.items = this.selectListView.props.items.filter(x => x != selectedItem)
-          this.selectListView.computeItems()
+        this.selectListView.props.items = this.selectListView.props.items.filter(x => x !== selectedItem)
+        this.selectListView.computeItems()
 
-          if(newSelection != selectedItem)
-          {
-            this.selectListView.selectItem(newSelection)
-          }
-          else
-          {
-              this.cancel()
-          }
+        if (newSelection !== selectedItem) {
+          this.selectListView.selectItem(newSelection)
+        }
+        else {
+          this.cancel()
         }
       }
+    }
   }
 
   moveToLine (lineNumber = -1) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -16,6 +16,9 @@ module.exports = {
       },
       'fuzzy-finder:toggle-git-status-finder': () => {
         this.createGitStatusView().toggle()
+      },
+      'fuzzy-finder:kill-tab':() => {
+        this.createBufferView().closeSelectedURI()
       }
     }))
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -17,7 +17,7 @@ module.exports = {
       'fuzzy-finder:toggle-git-status-finder': () => {
         this.createGitStatusView().toggle()
       },
-      'fuzzy-finder:kill-tab':() => {
+      'fuzzy-finder:kill-tab': () => {
         this.createBufferView().closeSelectedURI()
       }
     }))

--- a/menus/fuzzy-finder.cson
+++ b/menus/fuzzy-finder.cson
@@ -4,5 +4,6 @@
     { 'label': 'Find Buffer', 'command': 'fuzzy-finder:toggle-buffer-finder' }
     { 'label': 'Find File', 'command': 'fuzzy-finder:toggle-file-finder' }
     { 'label': 'Find Modified File', 'command': 'fuzzy-finder:toggle-git-status-finder' }
+    { 'label': 'Kill Tab', 'command': 'fuzzy-finder:kill-tab' }
   ]
 ]

--- a/package.json
+++ b/package.json
@@ -80,5 +80,10 @@
       "default": false,
       "description": "Prefills search query with selected in current editor text"
     }
+  },
+  "apmInstallSource": {
+    "type": "git",
+    "source": "oxilumin/fuzzy-finder",
+    "sha": "7dc33bb9d2a5671f497fd79f2e27d438cf809db0"
   }
 }


### PR DESCRIPTION
### Description of the Change

A new command to kill a tab is added.
As long as the tab being closed is not the last tab on the list - move selection to the next tab. If tab is the last tab - move selection to the new "last" tab after removal to avoid selection-jumping in long lists.
If the tab being closed is the last tab - close it and the popup.

### Benefits

When working in mouse-less setup it's not very convenient to close tabs by activating them and then closing each one separately. This basically copies feature from sublime text

### Possible Drawbacks

None

### Applicable Issues

None
