### PR TITLE
Correctly update the caption during line number entry

### DIFF
--- a/lib/fuzzy-finder-view.js
+++ b/lib/fuzzy-finder-view.js
@@ -43,21 +43,22 @@ class FuzzyFinderView {
           this.iconDisposables = null
         }
         const isLineJump = this.isQueryALineJump()
-        if (isLineJump && /\D/.test(this.selectListView.getQuery().substr(1))) {
+        if (isLineJump) {
           this.previousQueryWasLineJump = true
-          this.selectListView.update({
-            items: [],
-            emptyMessage: null,
-            errorMessage: 'Invalid line number'
-          })
-        } else if (!this.previousQueryWasLineJump && isLineJump) {
-          this.previousQueryWasLineJump = true
-          this.selectListView.update({
-            items: [],
-            emptyMessage: 'Jump to line in active editor',
-            errorMessage: null
-          })
-        } else if (this.previousQueryWasLineJump && !isLineJump) {
+          if (/\D/.test(this.selectListView.getQuery().substr(1))) {
+            this.selectListView.update({
+              items: [],
+              emptyMessage: null,
+              errorMessage: 'Invalid line number'
+            })
+          } else {
+            this.selectListView.update({
+              items: [],
+              emptyMessage: 'Jump to line in active editor',
+              errorMessage: null
+            })
+          }
+        } else if (this.previousQueryWasLineJump) {
           this.previousQueryWasLineJump = false
           this.selectListView.update({
             items: this.items,

--- a/spec/fuzzy-finder-spec.js
+++ b/spec/fuzzy-finder-spec.js
@@ -924,6 +924,33 @@ describe('FuzzyFinder', () => {
           expect(atom.workspace.getActiveTextEditor()).toBe(editor1)
           expect(editor1.getCursorBufferPosition()).toEqual([8, 3])
         })
+        
+        it('updates the error message after further entry', async () => {
+          const [editor1, editor2] = atom.workspace.getTextEditors() // eslint-disable-line no-unused-vars
+          
+          const emptyMessage = 'Jump to line in active editor'
+          const errorMessage = 'Invalid line number'
+
+          await atom.workspace.open('sample.js')
+
+          expect(atom.workspace.getActiveTextEditor()).toBe(editor1)
+
+          await bufferView.toggle()
+
+          expect(atom.workspace.panelForItem(bufferView).isVisible()).toBe(true)
+          
+          bufferView.selectListView.refs.queryEditor.setText(':42')
+          await getOrScheduleUpdatePromise()
+          expect(bufferView.selectListView.refs.emptyMessage.innerText).toEqual(emptyMessage)
+          
+          bufferView.selectListView.refs.queryEditor.setText(':42a')
+          await getOrScheduleUpdatePromise()
+          expect(bufferView.selectListView.refs.errorMessage.innerText).toEqual(errorMessage)
+          
+          bufferView.selectListView.refs.queryEditor.setText(':42')
+          await getOrScheduleUpdatePromise()
+          expect(bufferView.selectListView.refs.emptyMessage.innerText).toEqual(emptyMessage)
+        })
       })
     })
   })

--- a/spec/fuzzy-finder-spec.js
+++ b/spec/fuzzy-finder-spec.js
@@ -924,10 +924,10 @@ describe('FuzzyFinder', () => {
           expect(atom.workspace.getActiveTextEditor()).toBe(editor1)
           expect(editor1.getCursorBufferPosition()).toEqual([8, 3])
         })
-        
+
         it('updates the error message after further entry', async () => {
           const [editor1, editor2] = atom.workspace.getTextEditors() // eslint-disable-line no-unused-vars
-          
+
           const emptyMessage = 'Jump to line in active editor'
           const errorMessage = 'Invalid line number'
 
@@ -938,15 +938,15 @@ describe('FuzzyFinder', () => {
           await bufferView.toggle()
 
           expect(atom.workspace.panelForItem(bufferView).isVisible()).toBe(true)
-          
+
           bufferView.selectListView.refs.queryEditor.setText(':42')
           await getOrScheduleUpdatePromise()
           expect(bufferView.selectListView.refs.emptyMessage.innerText).toEqual(emptyMessage)
-          
+
           bufferView.selectListView.refs.queryEditor.setText(':42a')
           await getOrScheduleUpdatePromise()
           expect(bufferView.selectListView.refs.errorMessage.innerText).toEqual(errorMessage)
-          
+
           bufferView.selectListView.refs.queryEditor.setText(':42')
           await getOrScheduleUpdatePromise()
           expect(bufferView.selectListView.refs.emptyMessage.innerText).toEqual(emptyMessage)


### PR DESCRIPTION
### Description of the Change

As outlined in #358, the status message of the fuzzy finder did not update correctly while entering line numbers. This was due to an issue within the logic used to update the status message: The alert was not replaced by the standard message when the input became valid again because the `previousQueryWasLineJump` flag would stay true during the process, preventing the necessary block of code to be run.

The changes within this pull request fix this issue while simplifying the code in question a bit.

This is my first contribution to Atom, and I hope I did everything right. Do point me towards any mistakes I might have made though.

### Alternate Designs

N/A

### Benefits

The fuzzy finder always displays an appropriate status message when entering line numbers, no longer misleading users.

### Possible Drawbacks

N/A

### Applicable Issues

#358
