### PR TITLE
Add feature to jump to columns within text lines

### DIFF
--- a/lib/fuzzy-finder-view.js
+++ b/lib/fuzzy-finder-view.js
@@ -227,7 +227,7 @@ class FuzzyFinderView {
     if (editor && caretPosition.row >= 0) {
       editor.scrollToBufferPosition(caretPosition, {center: true})
       editor.setCursorBufferPosition(caretPosition)
-      if (caretPosition.column == -1) {
+      if (caretPosition.column === -1) {
         editor.moveToFirstCharacterOfLine()
       }
     }

--- a/lib/fuzzy-finder-view.js
+++ b/lib/fuzzy-finder-view.js
@@ -156,18 +156,18 @@ class FuzzyFinderView {
 
   confirm ({uri} = {}, openOptions) {
     if (atom.workspace.getActiveTextEditor() && this.isQueryALineJump()) {
-      const lineNumber = this.getLineNumber()
+      const caretPosition = this.getCaretPosition()
       this.cancel()
-      this.moveToLine(lineNumber)
+      this.moveToCaretPosition(caretPosition)
     } else if (!uri) {
       this.cancel()
     } else if (fs.isDirectorySync(uri)) {
       this.selectListView.update({errorMessage: 'Selected path is a directory'})
       setTimeout(() => { this.selectListView.update({errorMessage: null}) }, 2000)
     } else {
-      const lineNumber = this.getLineNumber()
+      const caretPosition = this.getCaretPosition()
       this.cancel()
-      this.openURI(uri, lineNumber, openOptions)
+      this.openURI(uri, caretPosition, openOptions)
     }
   }
 
@@ -215,20 +215,19 @@ class FuzzyFinderView {
     }
   }
 
-  async openURI (uri, lineNumber, openOptions) {
+  async openURI (uri, caretPosition, openOptions) {
     if (uri) {
       await atom.workspace.open(uri, openOptions)
-      this.moveToLine(lineNumber)
+      this.moveToCaretPosition(caretPosition)
     }
   }
 
-  moveToLine (lineNumber = -1) {
-    if (lineNumber >= 0) { // account for NaNs
-      const editor = atom.workspace.getActiveTextEditor()
-      if (editor) {
-        const position = new Point(lineNumber, 0)
-        editor.scrollToBufferPosition(position, {center: true})
-        editor.setCursorBufferPosition(position)
+  moveToCaretPosition (caretPosition) {
+    const editor = atom.workspace.getActiveTextEditor()
+    if (editor && caretPosition.row >= 0) {
+      editor.scrollToBufferPosition(caretPosition, {center: true})
+      editor.setCursorBufferPosition(caretPosition)
+      if (caretPosition.column == -1) {
         editor.moveToFirstCharacterOfLine()
       }
     }
@@ -236,23 +235,23 @@ class FuzzyFinderView {
 
   splitOpenPath (splitFn) {
     const {uri} = this.selectListView.getSelectedItem() || {}
-    const lineNumber = this.getLineNumber()
+    const caretPosition = this.getCaretPosition()
     const editor = atom.workspace.getActiveTextEditor()
     const activePane = atom.workspace.getActivePane()
 
     if (this.isQueryALineJump() && editor) {
       this.previouslyFocusedElement = null
       splitFn(activePane)({copyActiveItem: true})
-      this.moveToLine(lineNumber)
+      this.moveToCaretPosition(caretPosition)
     } else if (!uri) {
       return // eslint-disable-line no-useless-return
     } else if (activePane) {
       this.previouslyFocusedElement = null
       splitFn(activePane)()
-      this.openURI(uri, lineNumber)
+      this.openURI(uri, caretPosition)
     } else {
       this.previouslyFocusedElement = null
-      this.openURI(uri, lineNumber)
+      this.openURI(uri, caretPosition)
     }
   }
 
@@ -263,14 +262,23 @@ class FuzzyFinderView {
     )
   }
 
-  getLineNumber () {
+  getCaretPosition () {
     const query = this.selectListView.getQuery()
-    const colon = query.indexOf(':')
-    if (colon === -1) {
-      return -1
-    } else {
-      return parseInt(query.slice(colon + 1)) - 1
+    const firstColon = query.indexOf(':')
+    const secondColon = query.indexOf(':', firstColon + 1)
+    let position = new Point(-1, -1)
+
+    if (firstColon !== -1) {
+      if (secondColon !== -1) {
+        position.row = parseInt(query.slice(firstColon + 1, secondColon)) - 1
+        const column = parseInt(query.slice(secondColon + 1))
+        position.column = isNaN(column) ? -1 : column
+      } else {
+        position.row = parseInt(query.slice(firstColon + 1)) - 1
+      }
     }
+
+    return position
   }
 
   setItems (items) {

--- a/spec/fuzzy-finder-spec.js
+++ b/spec/fuzzy-finder-spec.js
@@ -822,53 +822,160 @@ describe('FuzzyFinder', () => {
     })
 
     describe('when the colon is followed by numbers', () => {
-      describe('when the filter text has a file path', () => {
-        it('opens the selected path to that line number', async () => {
-          const [editor1, editor2] = atom.workspace.getTextEditors() // eslint-disable-line no-unused-vars
+      describe('when the numbers are not followed by another colon', () => {
+        describe('when the filter text has a file path', () => {
+          it('opens the selected path to that line number', async () => {
+            const [editor1, editor2] = atom.workspace.getTextEditors() // eslint-disable-line no-unused-vars
 
-          await bufferView.toggle()
+            await bufferView.toggle()
 
-          expect(atom.workspace.panelForItem(bufferView).isVisible()).toBe(true)
-          bufferView.selectListView.refs.queryEditor.setText('sample.js:4')
+            expect(atom.workspace.panelForItem(bufferView).isVisible()).toBe(true)
+            bufferView.selectListView.refs.queryEditor.setText('sample.js:4')
 
-          await getOrScheduleUpdatePromise()
+            await getOrScheduleUpdatePromise()
 
-          const {filePath} = bufferView.selectListView.getSelectedItem()
-          expect(atom.project.getDirectories()[0].resolve(filePath)).toBe(editor1.getPath())
+            const {filePath} = bufferView.selectListView.getSelectedItem()
+            expect(atom.project.getDirectories()[0].resolve(filePath)).toBe(editor1.getPath())
 
-          spyOn(bufferView, 'moveToCaretPosition').andCallThrough()
-          atom.commands.dispatch(bufferView.element, 'core:confirm')
+            spyOn(bufferView, 'moveToCaretPosition').andCallThrough()
+            atom.commands.dispatch(bufferView.element, 'core:confirm')
 
-          await conditionPromise(() => bufferView.moveToCaretPosition.callCount > 0)
+            await conditionPromise(() => bufferView.moveToCaretPosition.callCount > 0)
 
-          expect(atom.workspace.getActiveTextEditor()).toBe(editor1)
-          expect(editor1.getCursorBufferPosition()).toEqual([3, 4])
+            expect(atom.workspace.getActiveTextEditor()).toBe(editor1)
+            expect(editor1.getCursorBufferPosition()).toEqual([3, 4])
+          })
+        })
+
+        describe("when the filter text doesn't have a file path", () => {
+          it('moves the cursor in the active editor to that line number', async () => {
+            const [editor1, editor2] = atom.workspace.getTextEditors() // eslint-disable-line no-unused-vars
+
+            await atom.workspace.open('sample.js')
+
+            expect(atom.workspace.getActiveTextEditor()).toBe(editor1)
+
+            await bufferView.toggle()
+
+            expect(atom.workspace.panelForItem(bufferView).isVisible()).toBe(true)
+            bufferView.selectListView.refs.queryEditor.insertText(':4')
+
+            await getOrScheduleUpdatePromise()
+
+            expect(bufferView.element.querySelectorAll('li').length).toBe(0)
+            spyOn(bufferView, 'moveToCaretPosition').andCallThrough()
+            atom.commands.dispatch(bufferView.element, 'core:confirm')
+
+            await conditionPromise(() => bufferView.moveToCaretPosition.callCount > 0)
+
+            expect(atom.workspace.getActiveTextEditor()).toBe(editor1)
+            expect(editor1.getCursorBufferPosition()).toEqual([3, 4])
+          })
         })
       })
+      
+      describe('when the numbers are followed by another colon', () => {
+        describe('when the colon is followed by more numbers', () => {
+          describe('when the filter text has a file path', () => {
+            it('opens the selected path to that line number and column', async () => {
+              const [editor1, editor2] = atom.workspace.getTextEditors() // eslint-disable-line no-unused-vars
 
-      describe("when the filter text doesn't have a file path", () => {
-        it('moves the cursor in the active editor to that line number', async () => {
-          const [editor1, editor2] = atom.workspace.getTextEditors() // eslint-disable-line no-unused-vars
+              await bufferView.toggle()
 
-          await atom.workspace.open('sample.js')
+              expect(atom.workspace.panelForItem(bufferView).isVisible()).toBe(true)
+              bufferView.selectListView.refs.queryEditor.setText('sample.js:4:6')
 
-          expect(atom.workspace.getActiveTextEditor()).toBe(editor1)
+              await getOrScheduleUpdatePromise()
 
-          await bufferView.toggle()
+              const {filePath} = bufferView.selectListView.getSelectedItem()
+              expect(atom.project.getDirectories()[0].resolve(filePath)).toBe(editor1.getPath())
 
-          expect(atom.workspace.panelForItem(bufferView).isVisible()).toBe(true)
-          bufferView.selectListView.refs.queryEditor.insertText(':4')
+              spyOn(bufferView, 'moveToCaretPosition').andCallThrough()
+              atom.commands.dispatch(bufferView.element, 'core:confirm')
 
-          await getOrScheduleUpdatePromise()
+              await conditionPromise(() => bufferView.moveToCaretPosition.callCount > 0)
 
-          expect(bufferView.element.querySelectorAll('li').length).toBe(0)
-          spyOn(bufferView, 'moveToCaretPosition').andCallThrough()
-          atom.commands.dispatch(bufferView.element, 'core:confirm')
+              expect(atom.workspace.getActiveTextEditor()).toBe(editor1)
+              expect(editor1.getCursorBufferPosition()).toEqual([3, 6])
+            })
+          })
 
-          await conditionPromise(() => bufferView.moveToCaretPosition.callCount > 0)
+          describe("when the filter text doesn't have a file path", () => {
+            it('moves the cursor in the active editor to that line number and column', async () => {
+              const [editor1, editor2] = atom.workspace.getTextEditors() // eslint-disable-line no-unused-vars
 
-          expect(atom.workspace.getActiveTextEditor()).toBe(editor1)
-          expect(editor1.getCursorBufferPosition()).toEqual([3, 4])
+              await atom.workspace.open('sample.js')
+
+              expect(atom.workspace.getActiveTextEditor()).toBe(editor1)
+
+              await bufferView.toggle()
+
+              expect(atom.workspace.panelForItem(bufferView).isVisible()).toBe(true)
+              bufferView.selectListView.refs.queryEditor.insertText(':4:6')
+
+              await getOrScheduleUpdatePromise()
+
+              expect(bufferView.element.querySelectorAll('li').length).toBe(0)
+              spyOn(bufferView, 'moveToCaretPosition').andCallThrough()
+              atom.commands.dispatch(bufferView.element, 'core:confirm')
+
+              await conditionPromise(() => bufferView.moveToCaretPosition.callCount > 0)
+
+              expect(atom.workspace.getActiveTextEditor()).toBe(editor1)
+              expect(editor1.getCursorBufferPosition()).toEqual([3, 6])
+            })
+          })
+        })
+        
+        describe('when the colon is not followed by more numbers', () => {
+          describe('when the filter text has a file path', () => {
+            it('opens the file, jumps to the first character of the line and does not throw an error', async () => {
+              const [editor1, editor2] = atom.workspace.getTextEditors() // eslint-disable-line no-unused-vars
+
+              await bufferView.toggle()
+
+              expect(atom.workspace.panelForItem(bufferView).isVisible()).toBe(true)
+              bufferView.selectListView.refs.queryEditor.setText('sample.js:5:a')
+
+              await getOrScheduleUpdatePromise()
+
+              const {filePath} = bufferView.selectListView.getSelectedItem()
+              expect(atom.project.getDirectories()[0].resolve(filePath)).toBe(editor1.getPath())
+
+              spyOn(bufferView, 'moveToCaretPosition').andCallThrough()
+              atom.commands.dispatch(bufferView.element, 'core:confirm')
+
+              await conditionPromise(() => bufferView.moveToCaretPosition.callCount > 0)
+
+              expect(atom.workspace.getActiveTextEditor()).toBe(editor1)
+              expect(editor1.getCursorBufferPosition()).toEqual([4, 4])
+            })
+          })
+
+          describe("when the filter text doesn't have a file path", () => {
+            it('jumps to the first character of the line and does not throw an error', async () => {
+              const [editor1, editor2] = atom.workspace.getTextEditors() // eslint-disable-line no-unused-vars
+
+              await atom.workspace.open('sample.js')
+
+              expect(atom.workspace.getActiveTextEditor()).toBe(editor1)
+
+              await bufferView.toggle()
+
+              expect(atom.workspace.panelForItem(bufferView).isVisible()).toBe(true)
+              bufferView.selectListView.refs.queryEditor.setText(':5:a')
+
+              await getOrScheduleUpdatePromise()
+
+              spyOn(bufferView, 'moveToCaretPosition').andCallThrough()
+              atom.commands.dispatch(bufferView.element, 'core:confirm')
+
+              await conditionPromise(() => bufferView.moveToCaretPosition.callCount > 0)
+
+              expect(atom.workspace.getActiveTextEditor()).toBe(editor1)
+              expect(editor1.getCursorBufferPosition()).toEqual([4, 4])
+            })
+          })
         })
       })
     })

--- a/spec/fuzzy-finder-spec.js
+++ b/spec/fuzzy-finder-spec.js
@@ -873,7 +873,7 @@ describe('FuzzyFinder', () => {
           })
         })
       })
-      
+
       describe('when the numbers are followed by another colon', () => {
         describe('when the colon is followed by more numbers', () => {
           describe('when the filter text has a file path', () => {
@@ -926,7 +926,7 @@ describe('FuzzyFinder', () => {
             })
           })
         })
-        
+
         describe('when the colon is not followed by more numbers', () => {
           describe('when the filter text has a file path', () => {
             it('opens the file, jumps to the first character of the line and does not throw an error', async () => {

--- a/spec/fuzzy-finder-spec.js
+++ b/spec/fuzzy-finder-spec.js
@@ -836,10 +836,10 @@ describe('FuzzyFinder', () => {
           const {filePath} = bufferView.selectListView.getSelectedItem()
           expect(atom.project.getDirectories()[0].resolve(filePath)).toBe(editor1.getPath())
 
-          spyOn(bufferView, 'moveToLine').andCallThrough()
+          spyOn(bufferView, 'moveToCaretPosition').andCallThrough()
           atom.commands.dispatch(bufferView.element, 'core:confirm')
 
-          await conditionPromise(() => bufferView.moveToLine.callCount > 0)
+          await conditionPromise(() => bufferView.moveToCaretPosition.callCount > 0)
 
           expect(atom.workspace.getActiveTextEditor()).toBe(editor1)
           expect(editor1.getCursorBufferPosition()).toEqual([3, 4])
@@ -862,10 +862,10 @@ describe('FuzzyFinder', () => {
           await getOrScheduleUpdatePromise()
 
           expect(bufferView.element.querySelectorAll('li').length).toBe(0)
-          spyOn(bufferView, 'moveToLine').andCallThrough()
+          spyOn(bufferView, 'moveToCaretPosition').andCallThrough()
           atom.commands.dispatch(bufferView.element, 'core:confirm')
 
-          await conditionPromise(() => bufferView.moveToLine.callCount > 0)
+          await conditionPromise(() => bufferView.moveToCaretPosition.callCount > 0)
 
           expect(atom.workspace.getActiveTextEditor()).toBe(editor1)
           expect(editor1.getCursorBufferPosition()).toEqual([3, 4])
@@ -888,10 +888,10 @@ describe('FuzzyFinder', () => {
           const {filePath} = bufferView.selectListView.getSelectedItem()
           expect(atom.project.getDirectories()[0].resolve(filePath)).toBe(editor1.getPath())
 
-          spyOn(bufferView, 'moveToLine').andCallThrough()
+          spyOn(bufferView, 'moveToCaretPosition').andCallThrough()
           atom.commands.dispatch(bufferView.element, 'core:confirm')
 
-          await conditionPromise(() => bufferView.moveToLine.callCount > 0)
+          await conditionPromise(() => bufferView.moveToCaretPosition.callCount > 0)
 
           expect(atom.workspace.getActiveTextEditor()).toBe(editor1)
           expect(editor1.getCursorBufferPosition()).toEqual([8, 3])
@@ -916,10 +916,10 @@ describe('FuzzyFinder', () => {
           expect(bufferView.selectListView.refs.errorMessage.innerText).toEqual('Invalid line number')
 
           expect(bufferView.element.querySelectorAll('li').length).toBe(0)
-          spyOn(bufferView, 'moveToLine').andCallThrough()
+          spyOn(bufferView, 'moveToCaretPosition').andCallThrough()
           atom.commands.dispatch(bufferView.element, 'core:confirm')
 
-          await conditionPromise(() => bufferView.moveToLine.callCount > 0)
+          await conditionPromise(() => bufferView.moveToCaretPosition.callCount > 0)
 
           expect(atom.workspace.getActiveTextEditor()).toBe(editor1)
           expect(editor1.getCursorBufferPosition()).toEqual([8, 3])
@@ -1017,10 +1017,10 @@ describe('FuzzyFinder', () => {
         await getOrScheduleUpdatePromise()
 
         expect(bufferView.element.querySelectorAll('li').length).toBe(0)
-        spyOn(bufferView, 'moveToLine').andCallThrough()
+        spyOn(bufferView, 'moveToCaretPosition').andCallThrough()
         atom.commands.dispatch(bufferView.element, 'pane:split-left')
 
-        await conditionPromise(() => bufferView.moveToLine.callCount > 0)
+        await conditionPromise(() => bufferView.moveToCaretPosition.callCount > 0)
 
         expect(atom.workspace.getActiveTextEditor()).not.toBe(editor1)
         expect(atom.workspace.getActiveTextEditor().getPath()).toBe(editor1.getPath())


### PR DESCRIPTION
### Issue or RFC Endorsed by Atom's Maintainers

#115

### Description of the Change

Previously, a user could request to jump to a specific line of a file or within the current editor by entering a colon followed by the line number into the fuzzy finder. This pull request enhances this feature by adding functionality to jump to a specific column within that line using a second colon. For example, `file.js:4:6` would open `file.js` and move the cursor to column six of line four. If the user has not specified a valid column number, Atom behaves in the same way as before the introduction of this enhancement and jumps to the first character within the specified line.

**Important Note:** I fixed a bug within the fuzzy finder status messages in pull request #359. These changes will need to be pulled into this pull request and adapted to the new functionality before merging.

### Alternate Designs

N/A

### Possible Drawbacks

As far as I'm aware, there are no drawbacks since this functionality is of a purely additional nature. If the user only wants to jump to a line like in the old version, they can simply omit the second colon and Atom will behave just like before.

### Verification Process

I have tried out jumping to lines, both within an open editor and while jumping to another file. I did so both with and without additional column numbers, as well as invalid entries, in all possible combinations. I concluded that previous behaviour remains unchanged while the new functionality behaves as expected.

Furthermore, all existing regression tests ran successfully. These include test cases for a variety of different environment and input conditions. I recombined all of them with the ability of specifying column numbers, creating a set of new test cases for the newly added functionality. These run successfully as well.

### Release Notes

Added a feature to jump to a column of a line using a second colon, e.g. `file.js:4:6`