### PR TITLE
Remove unnecessary call to check if a path is ignored

### DIFF
--- a/lib/load-paths-handler.js
+++ b/lib/load-paths-handler.js
@@ -46,7 +46,7 @@ class PathLoader {
   }
 
   pathLoaded (loadedPath, done) {
-    if (!this.isIgnored(loadedPath) && !emittedPaths.has(loadedPath)) {
+    if (!emittedPaths.has(loadedPath)) {
       this.paths.push(loadedPath)
       emittedPaths.add(loadedPath)
     }


### PR DESCRIPTION
### Description of the Change

Based on some profiling, the most expensive part of crawling the list of files is to check if each of the discovered files/folder are being ignored by `git` (the [`isIgnored()`](https://github.com/atom/fuzzy-finder/blob/master/lib/load-paths-handler.js#L37-L46)  method). This is done by calling the [`git-utils`](https://github.com/atom/git-utils) package which internally calls [`libgit2`](https://github.com/libgit2/libgit2/blob/635693d3bc55770ec7a6640ba3f2f0ee434a6042/src/ignore.c#L517).

For medium to large repos (>30K files), `isIgnored()` takes ~80-90% of the crawling time 💀.

Fortunately, the crawling logic is currently doing unnecessary checks to `isIgnored()`, which results in performing almost the double of checks than needed.

By removing the additional call to `isIgnored()` we can cut by ~40% the time that takes to open the fuzzy finder for the first time on medium and large repos.

This is a short table with the perf gains based on the repo size:

| Type | Num Files | Time (master)  | Time (This PR) | Improvements  |
|---|---|---|---|---|
|  Small | 2K  | 1.3s  | 1.3s | 0%  |
|  Medium |  30K | 10.3s  | 6.2s  | **39.8%** 🎉  |
|  Large | 270K  |  97.3s  |  57.5s  |  **40.9%** 🎉 |

*(In order to measure the time, I've added a `console.time()` call [before creating the crawling task](https://github.com/atom/fuzzy-finder/blob/master/lib/path-loader.js#L14) and a `console.timeEnd()` on the [callback of the task](https://github.com/atom/fuzzy-finder/blob/master/lib/path-loader.js#L19)).*

The reason why this change is not impactful on small repos is because there seems to be some overhead when creating the `Task`, which dominates the time to crawl when there are not many files to check.

This is some impactful low hanging fruit for https://github.com/atom/fuzzy-finder/issues/271, but there are a few other improvements that I think we can do to the fuzzy finder to make it faster.

### Alternate Designs

N/A.

### Benefits

Time to open the fuzzy finder after the editor launch gets reduced by ~40% on large repositories.

### Verification Process

* Added some logging [on the call to the `callback`](https://github.com/atom/fuzzy-finder/blob/master/lib/path-loader.js#L19) to print all the project files that were crawled, stored them in disk and compared the list that gets generated with this PR against the one that gets generated in master. Verified that both lists are the same for several projects with different `.gitignore` configs (Atom, Jest, Gecko-dev).
* Manually verified that there are only two callsites to the `pathLoaded()` method ([1](https://github.com/atom/fuzzy-finder/blob/master/lib/load-paths-handler.js#L80) and [2](https://github.com/atom/fuzzy-finder/blob/master/lib/load-paths-handler.js#L96)). Both of them pass the same variable as argument (`pathToLoad`), which never gets reassigned. Before calling both callsites there's always a call to `isIgnored()` with the same variable argument (`pathToLoad`). This means that `isIgnored()` is called for the same exact paths than it was before (just less times).

### Possible Drawbacks

N/A.

### Applicable Issues

 https://github.com/atom/fuzzy-finder/issues/271
