### PR TITLE
RFC: use git ls to crawl all files in the project

### DIFF
--- a/lib/load-paths-handler.js
+++ b/lib/load-paths-handler.js
@@ -6,6 +6,8 @@ const path = require('path')
 const {GitRepository} = require('atom')
 const {Minimatch} = require('minimatch')
 
+const childProcess = require('child_process')
+
 const PathsChunkSize = 100
 
 const emittedPaths = new Set()
@@ -27,10 +29,43 @@ class PathLoader {
   }
 
   load (done) {
+    if (this.repo && !this.traverseSymlinkDirectories) {
+      this.loadFromGit().then(done)
+
+      return
+    }
+
     this.loadPath(this.rootPath, true, () => {
       this.flushPaths()
       if (this.repo != null) this.repo.destroy()
       done()
+    })
+  }
+
+  async loadFromGit () {
+    return new Promise((resolve) => {
+      const args = ['ls-files', '--cached', '--exclude-standard', '--others', '-z']
+
+      for (let ignoredName of this.ignoredNames) {
+        args.push('--exclude', ignoredName.pattern)
+      }
+
+      let output = ''
+
+      // TODO: do this via a call to GitRepository (needs to be implemented).
+      const result = childProcess.spawn('git', args, {cwd: this.rootPath})
+      result.stdout.on('data', chunk => {
+        const files = (output + chunk).split('\0')
+        output = files.pop()
+
+        for (const file of files) {
+          this.pathLoaded(file)
+        }
+      })
+      result.on('close', () => {
+        this.flushPaths()
+        resolve()
+      })
     })
   }
 
@@ -54,7 +89,8 @@ class PathLoader {
     if (this.paths.length === PathsChunkSize) {
       this.flushPaths()
     }
-    done()
+
+    done && done()
   }
 
   flushPaths () {


### PR DESCRIPTION
## Summary

This is some code to demonstrate the usage of `git ls-files` on the fuzzy finder, so we can discuss if it makes sense to implement this solution.

In terms of performance, this PR provides huge benefits for large repositories: for example it makes the crawling **5X faster** when opening the [`gecko-dev`](https://github.com/mozilla/gecko-dev) repository (it goes from 57s in the current implementation after merging #366 to 11s).

## Tradeoffs

Using `git ls-files` has to important tradeoffs:

1. It does not support symlinks (as stated in #301). To overcome this tradeoff I've decided to only enable this codepath whenever `traverseSymlinkDirectories` is `false` (which unfortunately would not happen often since it's enabled by default).
2. It does not support `git submodules`. This means that on a repo that has submodules the files inside these won't be accessible by the fuzzy finder.

The second tradeoff is quite a big deal, so if we ever want to enable this crawler we would want to have it under some kind of feature flag that could be enabled on the settings (e.g "Enable fast mode in fuzzy finder", showing some messaging around the tradeoffs of this mode.

Additionally, in order to make this mode more discoverable we could show some kind of prompt on the Atom UI whenever somebody opens a large project: if on the first crawling we detect that the repo has more than e.g 20K files we show a message suggesting enabling the fast mode.

## Alternative solutions

This is a very ad-hoc solution for a very specific problem: It does not fix the current architectural issues on the Fuzzy Finder around file watching, recrawling, etc.

If we want to invest some significant time into making an even greater Fuzzy Finder it would make more sense to address the architectural issues by creating some sort of global data structure that holds in memory all the project files and watches them for changes.

That "virtual filesystem" could probably be built on top of `@atom/watcher`, and could be used by other packages like the Tree View.

It's important to note that this alternative is way more complex to implement and would take much longer to ship.

## Next potential steps

This is just a WIP code to get some signal about whether we want to invest more on this path. if we want to move forward, there are a few things (some of them not trivial) that we'd need to do to be able to ship this:

- [ ] Implement the missing APIs on `git-utils` and `libgit2` to avoid spawning a `git` process.
- [ ] Add some kind of setting to enable this fast mode.
- [ ] Make the setting discoverable by adding a prompt on large projects.