### PR TITLE
Preview selected files in list #5 #182

### DIFF
--- a/lib/fuzzy-finder-view.js
+++ b/lib/fuzzy-finder-view.js
@@ -30,7 +30,7 @@ class FuzzyFinderView {
 
         return query
       },
-      didCancelSelection: () => { this.cancel() },
+      didCancelSelection: () => { this.cancel({ destroyPreview: true }) },
       didConfirmSelection: (item) => {
         this.confirm(item, {searchAllPanes: atom.config.get('fuzzy-finder.searchAllPanes')})
       },
@@ -44,8 +44,10 @@ class FuzzyFinderView {
         }
         const isLineJump = this.isQueryALineJump()
         if (isLineJump) {
+          this.showNextPreview = false
           this.previousQueryWasLineJump = true
-          const query = this.selectListView.getQuery()
+          this.lastQuery = this.selectListView.getQuery()
+          const query = this.lastQuery
           let emptyMessage = null
           let errorMessage = null
           if (/^:\d+:\d*\D/.test(query)) {
@@ -64,6 +66,7 @@ class FuzzyFinderView {
             errorMessage: errorMessage
           })
         } else if (this.previousQueryWasLineJump) {
+          this.showNextPreview = false
           this.previousQueryWasLineJump = false
           this.selectListView.update({
             items: this.items,
@@ -71,6 +74,31 @@ class FuzzyFinderView {
             errorMessage: null
           })
         }
+      },
+      didChangeSelection: (item) => {
+        if (!atom.config.get('core.allowPendingPaneItems') || !this.selectListView) {
+          return
+        }
+        if (this.selectListView.refs.loadingMessage) {
+          return
+        }
+        if (!this.showNextPreview || !item) {
+          this.showNextPreview = true
+          return
+        }
+
+        const query = this.selectListView.getQuery().trim()
+        if (this.lastQuery && !query) {
+          this.lastQuery = query
+          return
+        }
+        this.lastQuery = query
+
+        this.preview(item, {
+          searchAllPanes: atom.config.get('fuzzy-finder.searchAllPanes'),
+          pending: true,
+          activatePane: false
+        })
       },
       elementForItem: ({filePath, label, ownerGitHubUsername}) => {
         const filterQuery = this.selectListView.getFilterQuery()
@@ -150,11 +178,20 @@ class FuzzyFinderView {
     return this.selectListView.destroy()
   }
 
-  cancel () {
+  cancel ({destroyPreview} = {}) {
     if (atom.config.get('fuzzy-finder.preserveLastSearch')) {
       this.selectListView.refs.queryEditor.selectAll()
     } else {
       this.selectListView.reset()
+    }
+
+    if (atom.config.get('core.allowPendingPaneItems') && destroyPreview) {
+      const activePane = atom.workspace.getActivePane()
+      const pendingEditor = activePane.getPendingItem()
+
+      if (pendingEditor) {
+        pendingEditor.destroy()
+      }
     }
 
     this.hide()
@@ -173,6 +210,13 @@ class FuzzyFinderView {
     } else {
       const caretPosition = this.getCaretPosition()
       this.cancel()
+      this.openURI(uri, caretPosition, openOptions)
+    }
+  }
+
+  preview ({uri} = {}, openOptions) {
+    if (uri) {
+      const caretPosition = this.getCaretPosition()
       this.openURI(uri, caretPosition, openOptions)
     }
   }
@@ -200,6 +244,7 @@ class FuzzyFinderView {
 
   show () {
     this.previouslyFocusedElement = document.activeElement
+    this.showNextPreview = false
     if (!this.panel) {
       this.panel = atom.workspace.addModalPanel({item: this})
     }

--- a/lib/fuzzy-finder-view.js
+++ b/lib/fuzzy-finder-view.js
@@ -76,7 +76,7 @@ class FuzzyFinderView {
         }
       },
       didChangeSelection: (item) => {
-        if (!atom.config.get('core.allowPendingPaneItems') || !this.selectListView) {
+        if (!atom.config.get('fuzzy-finder.allowPendingPaneItems') || !this.selectListView) {
           return
         }
         if (this.selectListView.refs.loadingMessage) {
@@ -185,7 +185,7 @@ class FuzzyFinderView {
       this.selectListView.reset()
     }
 
-    if (atom.config.get('core.allowPendingPaneItems') && destroyPreview) {
+    if (atom.config.get('fuzzy-finder.allowPendingPaneItems') && destroyPreview) {
       const activePane = atom.workspace.getActivePane()
       const pendingEditor = activePane.getPendingItem()
 
@@ -243,8 +243,12 @@ class FuzzyFinderView {
   }
 
   show () {
-    this.previouslyFocusedElement = document.activeElement
     this.showNextPreview = false
+    this.previouslyFocusedElement = document.activeElement
+
+    if (atom.workspace.getActiveTextEditor()) {
+      this.previouslyFocusedEditor = atom.workspace.getActiveTextEditor()
+    }
     if (!this.panel) {
       this.panel = atom.workspace.addModalPanel({item: this})
     }
@@ -258,6 +262,12 @@ class FuzzyFinderView {
   hide () {
     if (this.panel) {
       this.panel.hide()
+    }
+
+    const editorPane = atom.workspace.paneForItem(this.previouslyFocusedEditor)
+    if (this.previouslyFocusedEditor && editorPane) {
+      editorPane.setActiveItem(this.previouslyFocusedEditor)
+      this.previouslyFocusedEditor = null
     }
 
     if (this.previouslyFocusedElement) {

--- a/lib/fuzzy-finder-view.js
+++ b/lib/fuzzy-finder-view.js
@@ -30,13 +30,16 @@ class FuzzyFinderView {
 
         return query
       },
-      didCancelSelection: () => { this.cancel({ destroyPreview: true }) },
+      didCancelSelection: () => {
+        this.cancelPreview()
+        this.cancel()
+      },
       didConfirmSelection: (item) => {
+        this.selectionConfirmed = true
         this.confirm(item, {searchAllPanes: atom.config.get('fuzzy-finder.searchAllPanes')})
       },
-      didConfirmEmptySelection: () => {
-        this.confirm()
-      },
+      didConfirmEmptySelection: () => { this.confirm() },
+      didChangeSelection: (item) => { this.preview(item) },
       didChangeQuery: () => {
         if (this.iconDisposables) {
           this.iconDisposables.dispose()
@@ -74,31 +77,6 @@ class FuzzyFinderView {
             errorMessage: null
           })
         }
-      },
-      didChangeSelection: (item) => {
-        if (!atom.config.get('fuzzy-finder.allowPendingPaneItems') || !this.selectListView) {
-          return
-        }
-        if (this.selectListView.refs.loadingMessage) {
-          return
-        }
-        if (!this.showNextPreview || !item) {
-          this.showNextPreview = true
-          return
-        }
-
-        const query = this.selectListView.getQuery().trim()
-        if (this.lastQuery && !query) {
-          this.lastQuery = query
-          return
-        }
-        this.lastQuery = query
-
-        this.preview(item, {
-          searchAllPanes: atom.config.get('fuzzy-finder.searchAllPanes'),
-          pending: true,
-          activatePane: false
-        })
       },
       elementForItem: ({filePath, label, ownerGitHubUsername}) => {
         const filterQuery = this.selectListView.getFilterQuery()
@@ -178,20 +156,11 @@ class FuzzyFinderView {
     return this.selectListView.destroy()
   }
 
-  cancel ({destroyPreview} = {}) {
+  cancel () {
     if (atom.config.get('fuzzy-finder.preserveLastSearch')) {
       this.selectListView.refs.queryEditor.selectAll()
     } else {
       this.selectListView.reset()
-    }
-
-    if (atom.config.get('fuzzy-finder.allowPendingPaneItems') && destroyPreview) {
-      const activePane = atom.workspace.getActivePane()
-      const pendingEditor = activePane.getPendingItem()
-
-      if (pendingEditor) {
-        pendingEditor.destroy()
-      }
     }
 
     this.hide()
@@ -214,10 +183,53 @@ class FuzzyFinderView {
     }
   }
 
-  preview ({uri} = {}, openOptions) {
+  preview (item) {
+    if (!this.allowPendingPaneItems() || !this.selectListView) {
+      return
+    }
+    if (this.selectListView.refs.loadingMessage) {
+      return
+    }
+    if (!this.showNextPreview || !item) {
+      this.showNextPreview = true
+      return
+    }
+    const query = this.selectListView.getQuery().trim()
+    if (this.lastQuery && !query) {
+      this.lastQuery = query
+      return
+    }
+    this.lastQuery = query
+
+    this.previewUri(item, {
+      searchAllPanes: atom.config.get('fuzzy-finder.searchAllPanes'),
+      pending: true,
+      activatePane: false
+    })
+  }
+
+  previewUri ({uri} = {}, openOptions) {
     if (uri) {
       const caretPosition = this.getCaretPosition()
       this.openURI(uri, caretPosition, openOptions)
+    }
+  }
+
+  cancelPreview () {
+    if (!this.allowPendingPaneItems()) {
+      return
+    }
+    const pane = atom.workspace.paneForItem(this.originalActiveEditor)
+    if (pane) {
+      const pendingEditor = pane.getPendingItem()
+      const pendingEditorIsNotActive = (pendingEditor !== atom.workspace.getActiveTextEditor())
+      if (!this.selectionConfirmed || pendingEditorIsNotActive) {
+        pane.removeItem(pendingEditor)
+      }
+      if (!this.selectionConfirmed && this.originalActiveEditor) {
+        pane.setActiveItem(this.originalActiveEditor)
+        this.originalActiveEditor = null
+      }
     }
   }
 
@@ -243,11 +255,12 @@ class FuzzyFinderView {
   }
 
   show () {
+    this.selectionConfirmed = false
     this.showNextPreview = false
     this.previouslyFocusedElement = document.activeElement
 
     if (atom.workspace.getActiveTextEditor()) {
-      this.previouslyFocusedEditor = atom.workspace.getActiveTextEditor()
+      this.originalActiveEditor = atom.workspace.getActiveTextEditor()
     }
     if (!this.panel) {
       this.panel = atom.workspace.addModalPanel({item: this})
@@ -262,12 +275,6 @@ class FuzzyFinderView {
   hide () {
     if (this.panel) {
       this.panel.hide()
-    }
-
-    const editorPane = atom.workspace.paneForItem(this.previouslyFocusedEditor)
-    if (this.previouslyFocusedEditor && editorPane) {
-      editorPane.setActiveItem(this.previouslyFocusedEditor)
-      this.previouslyFocusedEditor = null
     }
 
     if (this.previouslyFocusedElement) {
@@ -368,6 +375,13 @@ class FuzzyFinderView {
     }
 
     return this.projectRelativePaths
+  }
+
+  allowPendingPaneItems () {
+    return (
+      atom.config.get('core.allowPendingPaneItems') &&
+      atom.config.get('fuzzy-finder.allowPendingPaneItems')
+    )
   }
 }
 

--- a/lib/fuzzy-finder-view.js
+++ b/lib/fuzzy-finder-view.js
@@ -219,17 +219,19 @@ class FuzzyFinderView {
     if (!this.allowPendingPaneItems()) {
       return
     }
-    const pane = atom.workspace.paneForItem(this.originalActiveEditor)
-    if (pane) {
-      const pendingEditor = pane.getPendingItem()
-      const pendingEditorIsNotActive = (pendingEditor !== atom.workspace.getActiveTextEditor())
-      if (!this.selectionConfirmed || pendingEditorIsNotActive) {
-        pane.removeItem(pendingEditor)
-      }
-      if (!this.selectionConfirmed && this.originalActiveEditor) {
-        pane.setActiveItem(this.originalActiveEditor)
-        this.originalActiveEditor = null
-      }
+    const originalPane = atom.workspace.paneForItem(this.originalEditor)
+    const activeEditor = atom.workspace.getActiveTextEditor()
+    const pane = originalPane || atom.workspace.paneForItem(activeEditor)
+    if (!pane) {
+      return
+    }
+    const pendingEditor = pane.getPendingItem()
+    if (!this.selectionConfirmed || (pendingEditor !== activeEditor)) {
+      pane.removeItem(pendingEditor)
+    }
+    if (this.originalEditor) {
+      pane.setActiveItem(this.originalEditor)
+      this.originalEditor = null
     }
   }
 
@@ -260,7 +262,7 @@ class FuzzyFinderView {
     this.previouslyFocusedElement = document.activeElement
 
     if (atom.workspace.getActiveTextEditor()) {
-      this.originalActiveEditor = atom.workspace.getActiveTextEditor()
+      this.originalEditor = atom.workspace.getActiveTextEditor()
     }
     if (!this.panel) {
       this.panel = atom.workspace.addModalPanel({item: this})

--- a/package.json
+++ b/package.json
@@ -65,10 +65,10 @@
       "default": false,
       "description": "Search all panes when opening files. If disabled, only the active pane is searched. Holding `shift` inverts this setting."
     },
-    "preserveLastSearch": {
+    "allowPendingPaneItems": {
       "type": "boolean",
       "default": false,
-      "description": "Remember the typed query when closing the fuzzy finder and use that as the starting query next time the fuzzy finder is opened."
+      "description": "Allow the selected item to be previewed without permanently adding it to the pane."
     },
     "useAlternateScoring": {
       "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -65,10 +65,10 @@
       "default": false,
       "description": "Search all panes when opening files. If disabled, only the active pane is searched. Holding `shift` inverts this setting."
     },
-    "allowPendingPaneItems": {
+    "preserveLastSearch": {
       "type": "boolean",
       "default": false,
-      "description": "Allow the selected item to be previewed without permanently adding it to the pane."
+      "description": "Remember the typed query when closing the fuzzy finder and use that as the starting query next time the fuzzy finder is opened."
     },
     "useAlternateScoring": {
       "type": "boolean",
@@ -79,6 +79,11 @@
       "type": "boolean",
       "default": false,
       "description": "Prefills search query with selected in current editor text"
+    },
+    "allowPendingPaneItems": {
+      "type": "boolean",
+      "default": false,
+      "description": "Allow the selected item to be previewed without permanently adding it to the pane."
     }
   }
 }

--- a/spec/fuzzy-finder-spec.js
+++ b/spec/fuzzy-finder-spec.js
@@ -1208,6 +1208,38 @@ describe('FuzzyFinder', () => {
     })
   })
 
+  describe('allow pending pane items', () => {
+    beforeEach(() => {
+      atom.config.set('core.allowPendingPaneItems', true)
+      jasmine.attachToDOM(workspaceElement)
+      pane = atom.workspace.getActivePane()
+    })
+
+    it('does not open a preview on initial selection', async () => {
+      expect(atom.workspace.getTextEditors().length).toEqual(1)
+
+      await projectView.toggle()
+      await waitForPathsToDisplay(projectView)
+
+      expect(atom.workspace.getTextEditors().length).toEqual(1)
+      expect(pane.getPendingItem()).toBeNull()
+    })
+
+    it('opens a preview when there is a new selection', async () => {
+      await projectView.toggle()
+      await waitForPathsToDisplay(projectView)
+
+      spyOn(projectView, 'preview').andCallThrough()
+
+      projectView.selectListView.refs.queryEditor.setText('sample.html')
+
+      await conditionPromise(() => projectView.preview.callCount > 0)
+
+      expect(atom.workspace.getTextEditors().length).toEqual(2)
+      expect(pane.getPendingItem()).toBe(atom.workspace.getActiveTextEditor())
+    })
+  })
+
   describe('preserve last search', () => {
     it('does not preserve last search by default', async () => {
       await projectView.toggle()

--- a/spec/fuzzy-finder-spec.js
+++ b/spec/fuzzy-finder-spec.js
@@ -1209,6 +1209,8 @@ describe('FuzzyFinder', () => {
   })
 
   describe('allow pending pane items', () => {
+    let pane
+
     beforeEach(() => {
       atom.config.set('fuzzy-finder.allowPendingPaneItems', true)
       jasmine.attachToDOM(workspaceElement)
@@ -1252,12 +1254,12 @@ describe('FuzzyFinder', () => {
 
         await conditionPromise(() => projectView.preview.callCount > 0)
 
-        expect(pane.getPendingItem()).toBe(atom.workspace.getActiveTextEditor())
+        expect(pane.getPendingItem()).toEqual(atom.workspace.getActiveTextEditor())
 
-        await projectView.toggle()
+        atom.commands.dispatch(projectView.element, 'core:cancel')
 
-        expect(originalEditor).toBe(atom.workspace.getActiveTextEditor())
-        expect(pane.getPendingItem()).toBeNull
+        expect(originalEditor).toEqual(atom.workspace.getActiveTextEditor())
+        expect(pane.getPendingItem()).toBeNull()
       })
 
       it('switches back to the original editor when a preview is not open', async () => {
@@ -1276,12 +1278,12 @@ describe('FuzzyFinder', () => {
 
         await conditionPromise(() => projectView.preview.callCount > 0)
 
-        expect(otherEditor).toBe(atom.workspace.getActiveTextEditor())
-        expect(pane.getPendingItem()).toBeNull
+        expect(otherEditor).toEqual(atom.workspace.getActiveTextEditor())
+        expect(pane.getPendingItem()).toBeNull()
 
-        await projectView.toggle()
+        atom.commands.dispatch(projectView.element, 'core:cancel')
 
-        expect(originalEditor).toBe(atom.workspace.getActiveTextEditor())
+        expect(originalEditor).toEqual(atom.workspace.getActiveTextEditor())
       })
     })
   })


### PR DESCRIPTION
### Description of the Change

It has been brought up in a few issues and PRs (#113, #313) that having a Sublime Text like preview in the fuzzy finder would be helpful. This implementation should behave identical to Sublime's finder preview.

`didChangeSelection` gives a callback for user query changes in the fuzzy finder, and fortunately after that Atom's existing pending panes can handle the hard part.

### Alternate Designs

`didChangeSelection` is a little awkward to use because it's called more often than exactly when a user makes a change. For example when initially opening the fuzzy finder it can be called twice, so `this.showNextPreview` is needed to skip those events. I think a better solution would involve changes to `SelectListView` which is probably more than this issue warrants.

### Benefits

Allow possibly faster/easier decision making when selecting files, especially when searching for similar items. Also to make Sublime Text users happy :)

### Possible Drawbacks

There should be no impact when the feature is disabled. I haven't noticed any issues so far when enabled.

### Applicable Issues

#5, #182

![Mar-10-2019 03-44-40](https://user-images.githubusercontent.com/1145873/54083257-e269b300-42e6-11e9-82fa-2b866438fbcd.gif)
