### PR TITLE
Add option to use `ripgrep` for crawling the list of files

### DIFF
--- a/lib/load-paths-handler.js
+++ b/lib/load-paths-handler.js
@@ -11,6 +11,9 @@ const { rgPath } = require('vscode-ripgrep')
 
 const PathsChunkSize = 100
 
+// Use the unpacked path if the ripgrep binary is in asar archive.
+const realRgPath = rgPath.replace(/\bapp\.asar\b/, 'app.asar.unpacked')
+
 // Define the maximum number of concurrent crawling processes based on the number of CPUs
 // with a maximum value of 8 and minimum of 1.
 const MaxConcurrentCrawls = Math.min(Math.max(os.cpus().length - 1, 8), 1)
@@ -65,7 +68,7 @@ class PathLoader {
       }
 
       let output = ''
-      const result = childProcess.spawn(rgPath, args, {cwd: this.rootPath})
+      const result = childProcess.spawn(realRgPath, args, {cwd: this.rootPath})
 
       result.stdout.on('data', chunk => {
         const files = (output + chunk).split('\n')

--- a/lib/load-paths-handler.js
+++ b/lib/load-paths-handler.js
@@ -21,7 +21,7 @@ class PathLoader {
     this.paths = []
     this.inodes = new Set()
     this.repo = null
-    if (ignoreVcsIgnores) {
+    if (ignoreVcsIgnores && !this.useRipGrep) {
       const repo = GitRepository.open(this.rootPath, {refreshOnWindowFocus: false})
       if ((repo && repo.relativize(path.join(this.rootPath, 'test'))) === 'test') {
         this.repo = repo

--- a/lib/load-paths-handler.js
+++ b/lib/load-paths-handler.js
@@ -2,6 +2,7 @@
 
 const async = require('async')
 const fs = require('fs')
+const os = require('os')
 const path = require('path')
 const {GitRepository} = require('atom')
 const {Minimatch} = require('minimatch')
@@ -9,6 +10,10 @@ const childProcess = require('child_process')
 const { rgPath } = require('vscode-ripgrep')
 
 const PathsChunkSize = 100
+
+// Define the maximum number of concurrent crawling processes based on the number of CPUs
+// with a maximum value of 8 and minimum of 1.
+const MaxConcurrentCrawls = Math.min(Math.max(os.cpus().length - 1, 8), 1)
 
 const emittedPaths = new Set()
 
@@ -169,8 +174,9 @@ module.exports = function (rootPaths, followSymlinks, ignoreVcsIgnores, ignores,
     }
   }
 
-  async.each(
+  async.eachLimit(
     rootPaths,
+    MaxConcurrentCrawls,
     (rootPath, next) =>
       new PathLoader(
         rootPath,

--- a/lib/load-paths-handler.js
+++ b/lib/load-paths-handler.js
@@ -5,16 +5,19 @@ const fs = require('fs')
 const path = require('path')
 const {GitRepository} = require('atom')
 const {Minimatch} = require('minimatch')
+const childProcess = require('child_process')
+const { rgPath } = require('vscode-ripgrep')
 
 const PathsChunkSize = 100
 
 const emittedPaths = new Set()
 
 class PathLoader {
-  constructor (rootPath, ignoreVcsIgnores, traverseSymlinkDirectories, ignoredNames) {
+  constructor (rootPath, ignoreVcsIgnores, traverseSymlinkDirectories, ignoredNames, useRipGrep) {
     this.rootPath = rootPath
     this.traverseSymlinkDirectories = traverseSymlinkDirectories
     this.ignoredNames = ignoredNames
+    this.useRipGrep = useRipGrep
     this.paths = []
     this.inodes = new Set()
     this.repo = null
@@ -27,10 +30,50 @@ class PathLoader {
   }
 
   load (done) {
+    if (this.useRipGrep) {
+      this.loadFromRipGrep().then(done)
+
+      return
+    }
+
     this.loadPath(this.rootPath, true, () => {
       this.flushPaths()
       if (this.repo != null) this.repo.destroy()
       done()
+    })
+  }
+
+  async loadFromRipGrep () {
+    return new Promise((resolve) => {
+      const args = ['--files', '--hidden', '--sort', 'path']
+
+      if (this.ignoreVcsIgnores) {
+        args.push('--no-ignore')
+      }
+
+      if (this.traverseSymlinkDirectories) {
+        args.push('--follow')
+      }
+
+      for (let ignoredName of this.ignoredNames) {
+        args.push('-g', '!' + ignoredName.pattern)
+      }
+
+      let output = ''
+      const result = childProcess.spawn(rgPath, args, {cwd: this.rootPath})
+
+      result.stdout.on('data', chunk => {
+        const files = (output + chunk).split('\n')
+        output = files.pop()
+
+        for (const file of files) {
+          this.pathLoaded(path.join(this.rootPath, file))
+        }
+      })
+      result.on('close', () => {
+        this.flushPaths()
+        resolve()
+      })
     })
   }
 
@@ -54,7 +97,7 @@ class PathLoader {
     if (this.paths.length === PathsChunkSize) {
       this.flushPaths()
     }
-    done()
+    done && done()
   }
 
   flushPaths () {
@@ -114,7 +157,7 @@ class PathLoader {
   }
 }
 
-module.exports = function (rootPaths, followSymlinks, ignoreVcsIgnores, ignores = []) {
+module.exports = function (rootPaths, followSymlinks, ignoreVcsIgnores, ignores, useRipGrep) {
   const ignoredNames = []
   for (let ignore of ignores) {
     if (ignore) {
@@ -133,7 +176,8 @@ module.exports = function (rootPaths, followSymlinks, ignoreVcsIgnores, ignores 
         rootPath,
         ignoreVcsIgnores,
         followSymlinks,
-        ignoredNames
+        ignoredNames,
+        useRipGrep
       ).load(next)
     ,
     this.async()

--- a/lib/path-loader.js
+++ b/lib/path-loader.js
@@ -10,13 +10,16 @@ module.exports = {
     ignoredNames = ignoredNames.concat(atom.config.get('core.ignoredNames') || [])
     const ignoreVcsIgnores = atom.config.get('core.excludeVcsIgnoredPaths')
     const projectPaths = atom.project.getPaths().map((path) => fs.realpathSync(path))
+    const useRipGrep = atom.config.get('fuzzy-finder.useRipGrep')
 
     const task = Task.once(
       taskPath,
       projectPaths,
       followSymlinks,
       ignoreVcsIgnores,
-      ignoredNames, () => callback(results)
+      ignoredNames,
+      useRipGrep,
+      () => callback(results)
     )
 
     task.on('load-paths:paths-found',

--- a/package-lock.json
+++ b/package-lock.json
@@ -718,6 +718,15 @@
         "write": "^0.2.1"
       }
     },
+    "formatio": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
+      "integrity": "sha1-XtPM1jZVEJc4NGXZlhmRAOhhYek=",
+      "dev": true,
+      "requires": {
+        "samsam": "~1.1"
+      }
+    },
     "fs-plus": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/fs-plus/-/fs-plus-3.0.2.tgz",
@@ -1117,6 +1126,12 @@
       "integrity": "sha1-9HGh2khr5g9quVXRcRVSPdHSVdU=",
       "dev": true
     },
+    "lolex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
+      "integrity": "sha1-fD2mL/yzDw9agKJWbKJORdigHzE=",
+      "dev": true
+    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -1491,6 +1506,12 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true
     },
+    "samsam": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
+      "integrity": "sha1-vsEf3IOp/aBjQBIQ5AF2wwJNFWc=",
+      "dev": true
+    },
     "semver": {
       "version": "5.3.0",
       "resolved": "http://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
@@ -1506,6 +1527,18 @@
         "glob": "^7.0.0",
         "interpret": "^1.0.0",
         "rechoir": "^0.6.2"
+      }
+    },
+    "sinon": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.17.4.tgz",
+      "integrity": "sha1-Tk/02Esgre4TE482rLEyyhzXLIM=",
+      "dev": true,
+      "requires": {
+        "formatio": "1.1.1",
+        "lolex": "1.3.2",
+        "samsam": "1.1.2",
+        "util": ">=0.10.3 <1"
       }
     },
     "slice-ansi": {
@@ -1720,6 +1753,15 @@
       "dev": true,
       "requires": {
         "os-homedir": "^1.0.0"
+      }
+    },
+    "util": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.11.1.tgz",
+      "integrity": "sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3"
       }
     },
     "util-deprecate": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1728,6 +1728,11 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
     },
+    "vscode-ripgrep": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/vscode-ripgrep/-/vscode-ripgrep-1.2.5.tgz",
+      "integrity": "sha512-n5XBm9od5hahpljw9T8wbkuMnAY7LlAG1OyEEtcCZEX9aCHFuBKSP0IcvciGRTbtWRovNuT83A2iRjt6PL3bLg=="
+    },
     "wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "minimatch": "~3.0.3",
     "temp": "~0.8.1",
     "underscore-plus": "^1.0.0",
+    "vscode-ripgrep": "^1.2.5",
     "wrench": "^1.5"
   },
   "devDependencies": {
@@ -74,6 +75,11 @@
       "type": "boolean",
       "default": true,
       "description": "Use an alternative scoring approach which prefers run of consecutive characters, acronyms and start of words. (Experimental)"
+    },
+    "useRipGrep": {
+      "type": "boolean",
+      "default": false,
+      "description": "Use the experimental `ripgrep` crawler. This will speed up substantially the indexing process on large projects."
     },
     "prefillFromSelection": {
       "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "useRipGrep": {
       "type": "boolean",
       "default": false,
-      "description": "Use the experimental `ripgrep` crawler. This will speed up substantially the indexing process on large projects."
+      "description": "Use the experimental `ripgrep` crawler. This will substantially speed up the indexing process on large projects."
     },
     "prefillFromSelection": {
       "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "wrench": "^1.5"
   },
   "devDependencies": {
+    "sinon": "1.17.4",
     "standard": "^10.0.3"
   },
   "standard": {

--- a/spec/fuzzy-finder-spec.js
+++ b/spec/fuzzy-finder-spec.js
@@ -3,6 +3,8 @@ const path = require('path')
 const _ = require('underscore-plus')
 const etch = require('etch')
 const fs = require('fs-plus')
+const os = require('os')
+const sinon = require('sinon')
 const temp = require('temp')
 const wrench = require('wrench')
 
@@ -81,7 +83,13 @@ describe('FuzzyFinder', () => {
 
   describe('file-finder behavior', () => {
     beforeEach(async () => {
+      sinon.stub(os, 'cpus').returns({length: 1})
+
       await projectView.selectListView.update({maxResults: null})
+    })
+
+    afterEach(() => {
+      os.cpus.restore()
     })
 
     describe('toggling', () => {
@@ -167,8 +175,10 @@ describe('FuzzyFinder', () => {
 
           await waitForPathsToDisplay(projectView)
 
-          expect(projectView.element.querySelectorAll('li')[0].textContent).toContain('sample.txt')
-          expect(projectView.element.querySelectorAll('li')[1].textContent).toContain('sample.html')
+          const results = projectView.element.querySelectorAll('li')
+
+          expect(results[0].textContent).toContain('sample.txt')
+          expect(results[results.length - 1].textContent).toContain('sample.html')
         })
 
         it('displays paths correctly if the last-opened path is not part of the project (regression)', async () => {

--- a/spec/fuzzy-finder-spec.js
+++ b/spec/fuzzy-finder-spec.js
@@ -81,766 +81,950 @@ describe('FuzzyFinder', () => {
     }
   }
 
-  describe('file-finder behavior', () => {
-    beforeEach(async () => {
-      sinon.stub(os, 'cpus').returns({length: 1})
-
-      await projectView.selectListView.update({maxResults: null})
-    })
-
-    afterEach(() => {
-      os.cpus.restore()
-    })
-
-    describe('toggling', () => {
-      describe('when the project has multiple paths', () => {
-        it('shows or hides the fuzzy-finder and returns focus to the active editor if it is already showing', async () => {
-          jasmine.attachToDOM(workspaceElement)
-
-          expect(atom.workspace.panelForItem(projectView)).toBeNull()
-          atom.workspace.getActivePane().splitRight({copyActiveItem: true})
-          const [editor1, editor2] = atom.workspace.getTextEditors()
-
-          await projectView.toggle()
-
-          expect(atom.workspace.panelForItem(projectView).isVisible()).toBe(true)
-          expect(projectView.selectListView.refs.queryEditor.element).toHaveFocus()
-          projectView.selectListView.refs.queryEditor.insertText('this should not show up next time we toggle')
-
-          await projectView.toggle()
-
-          expect(atom.views.getView(editor1)).not.toHaveFocus()
-          expect(atom.views.getView(editor2)).toHaveFocus()
-          expect(atom.workspace.panelForItem(projectView).isVisible()).toBe(false)
-
-          await projectView.toggle()
-
-          expect(projectView.selectListView.refs.queryEditor.getText()).toBe('')
-        })
-
-        it('shows all files for the current project and selects the first', async () => {
-          jasmine.attachToDOM(workspaceElement)
-
-          await projectView.toggle()
-
-          expect(projectView.element.querySelector('.loading').textContent.length).toBeGreaterThan(0)
-          await waitForPathsToDisplay(projectView)
-
-          eachFilePath([rootDir1, rootDir2], (filePath) => {
-            const item = Array.from(projectView.element.querySelectorAll('li')).find(a => a.textContent.includes(filePath))
-            expect(item).toExist()
-            const nameDiv = item.querySelector('div:first-child')
-            expect(nameDiv.dataset.name).toBe(path.basename(filePath))
-            expect(nameDiv.textContent).toBe(path.basename(filePath))
-          })
-
-          expect(projectView.element.querySelector('.loading')).not.toBeVisible()
-        })
-
-        it("shows each file's path, including which root directory it's in", async () => {
-          await projectView.toggle()
-
-          await waitForPathsToDisplay(projectView)
-
-          eachFilePath([rootDir1], (filePath) => {
-            const item = Array.from(projectView.element.querySelectorAll('li')).find(a => a.textContent.includes(filePath))
-            expect(item).toExist()
-            expect(item.querySelectorAll('div')[1].textContent).toBe(path.join(path.basename(rootDir1), filePath))
-          })
-
-          eachFilePath([rootDir2], (filePath) => {
-            const item = Array.from(projectView.element.querySelectorAll('li')).find(a => a.textContent.includes(filePath))
-            expect(item).toExist()
-            expect(item.querySelectorAll('div')[1].textContent).toBe(path.join(path.basename(rootDir2), filePath))
-          })
-        })
-
-        it('only creates a single path loader task', async () => {
-          spyOn(PathLoader, 'startTask').andCallThrough()
-
-          await projectView.toggle() // Show
-
-          await projectView.toggle() // Hide
-
-          await projectView.toggle() // Show again
-
-          expect(PathLoader.startTask.callCount).toBe(1)
-        })
-
-        it('puts the last opened path first', async () => {
-          await atom.workspace.open('sample.txt')
-          await atom.workspace.open('sample.js')
-
-          await projectView.toggle()
-
-          await waitForPathsToDisplay(projectView)
-
-          const results = projectView.element.querySelectorAll('li')
-
-          expect(results[0].textContent).toContain('sample.txt')
-          expect(results[results.length - 1].textContent).toContain('sample.html')
-        })
-
-        it('displays paths correctly if the last-opened path is not part of the project (regression)', async () => {
-          await atom.workspace.open('foo.txt')
-          await atom.workspace.open('sample.js')
-
-          await projectView.toggle()
-
-          await waitForPathsToDisplay(projectView)
-        })
-
-        describe('symlinks on #darwin or #linux', () => {
-          let junkDirPath, junkFilePath
-
-          beforeEach(() => {
-            junkDirPath = fs.realpathSync(temp.mkdirSync('junk-1'))
-            junkFilePath = path.join(junkDirPath, 'file.txt')
-            fs.writeFileSync(junkFilePath, 'txt')
-            fs.writeFileSync(path.join(junkDirPath, 'a'), 'txt')
-
-            const brokenFilePath = path.join(junkDirPath, 'delete.txt')
-            fs.writeFileSync(brokenFilePath, 'delete-me')
-
-            fs.symlinkSync(junkFilePath, atom.project.getDirectories()[0].resolve('symlink-to-file'))
-            fs.symlinkSync(junkDirPath, atom.project.getDirectories()[0].resolve('symlink-to-dir'))
-            fs.symlinkSync(brokenFilePath, atom.project.getDirectories()[0].resolve('broken-symlink'))
-
-            fs.symlinkSync(atom.project.getDirectories()[0].resolve('sample.txt'), atom.project.getDirectories()[0].resolve('symlink-to-internal-file'))
-            fs.symlinkSync(atom.project.getDirectories()[0].resolve('dir'), atom.project.getDirectories()[0].resolve('symlink-to-internal-dir'))
-            fs.symlinkSync(atom.project.getDirectories()[0].resolve('..'), atom.project.getDirectories()[0].resolve('symlink-to-project-dir-ancestor'))
-
-            fs.unlinkSync(brokenFilePath)
-          })
-
-          it('indexes project paths that are symlinks', async () => {
-            const symlinkProjectPath = path.join(junkDirPath, 'root-dir-symlink')
-            fs.symlinkSync(atom.project.getPaths()[0], symlinkProjectPath)
-
-            atom.project.setPaths([symlinkProjectPath])
-
-            await projectView.toggle()
-
-            await waitForPathsToDisplay(projectView)
-
-            expect(Array.from(projectView.element.querySelectorAll('li')).find(a => a.textContent.includes('sample.txt'))).toBeDefined()
-          })
-
-          it('includes symlinked file paths', async () => {
-            await projectView.toggle()
-
-            await waitForPathsToDisplay(projectView)
-
-            expect(Array.from(projectView.element.querySelectorAll('li')).find(a => a.textContent.includes('symlink-to-file'))).toBeDefined()
-            expect(Array.from(projectView.element.querySelectorAll('li')).find(a => a.textContent.includes('symlink-to-internal-file'))).not.toBeDefined()
-          })
-
-          it('excludes symlinked folder paths if followSymlinks is false', async () => {
-            atom.config.set('core.followSymlinks', false)
-
-            await projectView.toggle()
-
-            await waitForPathsToDisplay(projectView)
-
-            expect(Array.from(projectView.element.querySelectorAll('li')).find(a => a.textContent.includes('symlink-to-dir'))).not.toBeDefined()
-            expect(Array.from(projectView.element.querySelectorAll('li')).find(a => a.textContent.includes('symlink-to-dir/a'))).not.toBeDefined()
-
-            expect(Array.from(projectView.element.querySelectorAll('li')).find(a => a.textContent.includes('symlink-to-internal-dir'))).not.toBeDefined()
-            expect(Array.from(projectView.element.querySelectorAll('li')).find(a => a.textContent.includes('symlink-to-internal-dir/a'))).not.toBeDefined()
-          })
-
-          it('includes symlinked folder paths if followSymlinks is true', async () => {
-            atom.config.set('core.followSymlinks', true)
-
-            await projectView.toggle()
-
-            await waitForPathsToDisplay(projectView)
-
-            expect(Array.from(projectView.element.querySelectorAll('li')).find(a => a.textContent.includes('symlink-to-dir/a'))).toBeDefined()
-            expect(Array.from(projectView.element.querySelectorAll('li')).find(a => a.textContent.includes('symlink-to-internal-dir/a'))).not.toBeDefined()
-          })
-        })
-
-        describe('socket files on #darwin or #linux', () => {
-          let socketServer, socketPath
-
-          beforeEach(() => {
-            socketServer = net.createServer(() => {})
-            socketPath = path.join(rootDir1, 'some.sock')
-            waitsFor(done => socketServer.listen(socketPath, done))
-          })
-
-          afterEach(() => socketServer.close())
-
-          it('does not interfere with ability to load files', async () => {
-            await projectView.toggle()
-
-            await waitForPathsToDisplay(projectView)
-            expect(Array.from(projectView.element.querySelectorAll('li')).find(a => a.textContent.includes('a'))).toBeDefined()
-            expect(Array.from(projectView.element.querySelectorAll('li')).find(a => a.textContent.includes('some.sock'))).not.toBeDefined()
-          })
-        })
-
-        it('ignores paths that match entries in config.fuzzy-finder.ignoredNames', async () => {
-          atom.config.set('fuzzy-finder.ignoredNames', ['sample.js', '*.txt'])
-
-          await projectView.toggle()
-
-          await waitForPathsToDisplay(projectView)
-
-          expect(Array.from(projectView.element.querySelectorAll('li')).find(a => a.textContent.includes('sample.js'))).not.toBeDefined()
-          expect(Array.from(projectView.element.querySelectorAll('li')).find(a => a.textContent.includes('sample.txt'))).not.toBeDefined()
-          expect(Array.from(projectView.element.querySelectorAll('li')).find(a => a.textContent.includes('a'))).toBeDefined()
-        })
-
-        it("only shows a given path once, even if it's within multiple root folders", async () => {
-          const childDir1 = path.join(rootDir1, 'a-child')
-          const childFile1 = path.join(childDir1, 'child-file.txt')
-          fs.mkdirSync(childDir1)
-          fs.writeFileSync(childFile1, 'stuff')
-          atom.project.addPath(childDir1)
-
-          await projectView.toggle()
-
-          await waitForPathsToDisplay(projectView)
-
-          expect(Array.from(projectView.element.querySelectorAll('li')).filter(a => a.textContent.includes('child-file.txt')).length).toBe(1)
-        })
-      })
-
-      describe('when the project only has one path', () => {
-        beforeEach(() => atom.project.setPaths([rootDir1]))
-
-        it("doesn't show the name of each file's root directory", async () => {
-          await projectView.toggle()
-
-          await waitForPathsToDisplay(projectView)
-
-          const items = Array.from(projectView.element.querySelectorAll('li'))
-          eachFilePath([rootDir1], (filePath) => {
-            const item = items.find(a => a.textContent.includes(filePath))
-            expect(item).toExist()
-            expect(item).not.toHaveText(path.basename(rootDir1))
-          })
-        })
-      })
-
-      describe('when the project has no path', () => {
-        beforeEach(() => {
-          jasmine.attachToDOM(workspaceElement)
-          atom.project.setPaths([])
-        })
-
-        it('shows an empty message with no files in the list', async () => {
-          await projectView.toggle()
-
-          expect(projectView.selectListView.refs.emptyMessage).toBeVisible()
-          expect(projectView.selectListView.refs.emptyMessage.textContent).toBe('Project is empty')
-          expect(projectView.element.querySelectorAll('li').length).toBe(0)
-        })
-      })
-    })
-
-    describe("when a project's root path is unlinked", () => {
-      beforeEach(() => {
-        if (fs.existsSync(rootDir1)) { rmrf(rootDir1) }
-        if (fs.existsSync(rootDir2)) { rmrf(rootDir2) }
-      })
-
-      it('posts an error notification', async () => {
-        spyOn(atom.notifications, 'addError')
-        await projectView.toggle()
-
-        await conditionPromise(() => atom.workspace.panelForItem(projectView).isVisible())
-        expect(atom.notifications.addError).toHaveBeenCalled()
-      })
-    })
-
-    describe('when a path selection is confirmed', () => {
-      it('opens the file associated with that path in that split', async () => {
-        jasmine.attachToDOM(workspaceElement)
-        const editor1 = atom.workspace.getActiveTextEditor()
-        atom.workspace.getActivePane().splitRight({copyActiveItem: true})
-        const editor2 = atom.workspace.getActiveTextEditor()
-        const expectedPath = atom.project.getDirectories()[0].resolve('dir/a')
-
-        await projectView.toggle()
-
-        projectView.confirm({uri: expectedPath})
-
-        await conditionPromise(() => atom.workspace.getActivePane().getItems().length === 2)
-
-        const editor3 = atom.workspace.getActiveTextEditor()
-        expect(atom.workspace.panelForItem(projectView).isVisible()).toBe(false)
-        expect(editor1.getPath()).not.toBe(expectedPath)
-        expect(editor2.getPath()).not.toBe(expectedPath)
-        expect(editor3.getPath()).toBe(expectedPath)
-        expect(atom.views.getView(editor3)).toHaveFocus()
-      })
-
-      describe('when the selected path is a directory', () =>
-        it("leaves the the tree view open, doesn't open the path in the editor, and displays an error", async () => {
-          jasmine.attachToDOM(workspaceElement)
-          const editorPath = atom.workspace.getActiveTextEditor().getPath()
-          await projectView.toggle()
-
-          projectView.confirm({uri: atom.project.getDirectories()[0].resolve('dir')})
-          expect(projectView.element.parentElement).toBeDefined()
-          expect(atom.workspace.getActiveTextEditor().getPath()).toBe(editorPath)
-
-          await conditionPromise(() => projectView.selectListView.refs.errorMessage)
-
-          jasmine.useMockClock()
-
-          advanceClock(2000)
-
-          await conditionPromise(() => !projectView.selectListView.refs.errorMessage)
-        })
-      )
-    })
-  })
-
-  describe('buffer-finder behavior', () => {
-    describe('toggling', () => {
-      describe('when there are pane items with paths', () => {
-        beforeEach(async () => {
-          jasmine.attachToDOM(workspaceElement)
-
-          await atom.workspace.open('sample.txt')
-        })
-
-        it("shows the FuzzyFinder if it isn't showing, or hides it and returns focus to the active editor", async () => {
-          expect(atom.workspace.panelForItem(bufferView)).toBeNull()
-          atom.workspace.getActivePane().splitRight({copyActiveItem: true})
-          const [editor1, editor2, editor3] = atom.workspace.getTextEditors() // eslint-disable-line no-unused-vars
-          expect(atom.workspace.getActivePaneItem()).toBe(editor3)
-
-          expect(atom.views.getView(editor3)).toHaveFocus()
-
-          await bufferView.toggle()
-
-          expect(atom.workspace.panelForItem(bufferView).isVisible()).toBe(true)
-          expect(workspaceElement.querySelector('.fuzzy-finder')).toHaveFocus()
-          bufferView.selectListView.refs.queryEditor.insertText('this should not show up next time we toggle')
-
-          await bufferView.toggle()
-
-          expect(atom.views.getView(editor3)).toHaveFocus()
-          expect(atom.workspace.panelForItem(bufferView).isVisible()).toBe(false)
-
-          await bufferView.toggle()
-
-          expect(bufferView.selectListView.refs.queryEditor.getText()).toBe('')
-        })
-
-        it('lists the paths of the current items, sorted by most recently opened but with the current item last', async () => {
-          await atom.workspace.open('sample-with-tabs.coffee')
-
-          await bufferView.toggle()
-
-          expect(atom.workspace.panelForItem(bufferView).isVisible()).toBe(true)
-          expect(Array.from(bufferView.element.querySelectorAll('li > div.file')).map(e => e.textContent)).toEqual(['sample.txt', 'sample.js', 'sample-with-tabs.coffee'])
-
-          await bufferView.toggle()
-
-          expect(atom.workspace.panelForItem(bufferView).isVisible()).toBe(false)
-
-          await atom.workspace.open('sample.txt')
-
-          await bufferView.toggle()
-
-          expect(atom.workspace.panelForItem(bufferView).isVisible()).toBe(true)
-          expect(Array.from(bufferView.element.querySelectorAll('li > div.file')).map(e => e.textContent)).toEqual(['sample-with-tabs.coffee', 'sample.js', 'sample.txt'])
-          expect(bufferView.element.querySelector('li')).toHaveClass('selected')
-        })
-
-        it('serializes the list of paths and their last opened time', async () => {
-          await atom.workspace.open('sample-with-tabs.coffee')
-
-          await bufferView.toggle()
-
-          await atom.workspace.open('sample.js')
-
-          await bufferView.toggle()
-
-          await atom.workspace.open()
-
-          await atom.packages.deactivatePackage('fuzzy-finder')
-
-          let states = _.map(atom.packages.getPackageState('fuzzy-finder'), (path, time) => [path, time])
-          expect(states.length).toBe(3)
-          states = _.sortBy(states, (path, time) => -time)
-
-          const paths = ['sample-with-tabs.coffee', 'sample.txt', 'sample.js']
-
-          for (let [time, bufferPath] of states) {
-            expect(_.last(bufferPath.split(path.sep))).toBe(paths.shift())
-            expect(time).toBeGreaterThan(50000)
-          }
-        })
-      })
-
-      describe('when there are only panes with anonymous items', () =>
-        it('does not open', async () => {
-          atom.workspace.getActivePane().destroy()
-          await atom.workspace.open()
-
-          await bufferView.toggle()
-
-          expect(atom.workspace.panelForItem(bufferView)).toBeNull()
-        })
-      )
-
-      describe('when there are no pane items', () =>
-        it('does not open', async () => {
-          atom.workspace.getActivePane().destroy()
-          await bufferView.toggle()
-
-          expect(atom.workspace.panelForItem(bufferView)).toBeNull()
-        })
-      )
-
-      describe('when multiple sessions are opened on the same path', () =>
-        it('does not display duplicates for that path in the list', async () => {
-          await atom.workspace.open('sample.js')
-
-          atom.workspace.getActivePane().splitRight({copyActiveItem: true})
-
-          await bufferView.toggle()
-
-          expect(Array.from(bufferView.element.querySelectorAll('li > div.file')).map(e => e.textContent)).toEqual(['sample.js'])
-        })
-    )
-    })
-
-    describe('when a path selection is confirmed', () => {
-      let editor1, editor2, editor3
-
+  for (const useRipGrep of [false, true]) {
+    describe(`file-finder behavior (ripgrep=${useRipGrep})`, () => {
       beforeEach(async () => {
-        jasmine.attachToDOM(workspaceElement)
-        atom.workspace.getActivePane().splitRight({copyActiveItem: true})
+        atom.config.set('fuzzy-finder.useRipGrep', useRipGrep)
+        sinon.stub(os, 'cpus').returns({length: 1})
 
-        await atom.workspace.open('sample.txt');
-
-        [editor1, editor2, editor3] = atom.workspace.getTextEditors()
-
-        expect(atom.workspace.getActiveTextEditor()).toBe(editor3)
-
-        atom.commands.dispatch(atom.views.getView(editor2), 'pane:show-previous-item')
-
-        await bufferView.toggle()
+        await projectView.selectListView.update({maxResults: null})
       })
 
-      describe('when the active pane has an item for the selected path', () =>
-        it('switches to the item for the selected path', async () => {
-          const expectedPath = atom.project.getDirectories()[0].resolve('sample.txt')
-          bufferView.confirm({uri: expectedPath})
+      afterEach(() => {
+        os.cpus.restore()
+      })
 
-          await conditionPromise(() => atom.workspace.getActiveTextEditor().getPath() === expectedPath)
+      describe('toggling', () => {
+        describe('when the project has multiple paths', () => {
+          it('shows or hides the fuzzy-finder and returns focus to the active editor if it is already showing', async () => {
+            jasmine.attachToDOM(workspaceElement)
 
-          expect(atom.workspace.panelForItem(bufferView).isVisible()).toBe(false)
+            expect(atom.workspace.panelForItem(projectView)).toBeNull()
+            atom.workspace.getActivePane().splitRight({copyActiveItem: true})
+            const [editor1, editor2] = atom.workspace.getTextEditors()
+
+            await projectView.toggle()
+
+            expect(atom.workspace.panelForItem(projectView).isVisible()).toBe(true)
+            expect(projectView.selectListView.refs.queryEditor.element).toHaveFocus()
+            projectView.selectListView.refs.queryEditor.insertText('this should not show up next time we toggle')
+
+            await projectView.toggle()
+
+            expect(atom.views.getView(editor1)).not.toHaveFocus()
+            expect(atom.views.getView(editor2)).toHaveFocus()
+            expect(atom.workspace.panelForItem(projectView).isVisible()).toBe(false)
+
+            await projectView.toggle()
+
+            expect(projectView.selectListView.refs.queryEditor.getText()).toBe('')
+          })
+
+          it('shows all files for the current project and selects the first', async () => {
+            jasmine.attachToDOM(workspaceElement)
+
+            await projectView.toggle()
+
+            expect(projectView.element.querySelector('.loading').textContent.length).toBeGreaterThan(0)
+            await waitForPathsToDisplay(projectView)
+
+            eachFilePath([rootDir1, rootDir2], (filePath) => {
+              const item = Array.from(projectView.element.querySelectorAll('li')).find(a => a.textContent.includes(filePath))
+              expect(item).toExist()
+              const nameDiv = item.querySelector('div:first-child')
+              expect(nameDiv.dataset.name).toBe(path.basename(filePath))
+              expect(nameDiv.textContent).toBe(path.basename(filePath))
+            })
+
+            expect(projectView.element.querySelector('.loading')).not.toBeVisible()
+          })
+
+          it("shows each file's path, including which root directory it's in", async () => {
+            await projectView.toggle()
+
+            await waitForPathsToDisplay(projectView)
+
+            eachFilePath([rootDir1], (filePath) => {
+              const item = Array.from(projectView.element.querySelectorAll('li')).find(a => a.textContent.includes(filePath))
+              expect(item).toExist()
+              expect(item.querySelectorAll('div')[1].textContent).toBe(path.join(path.basename(rootDir1), filePath))
+            })
+
+            eachFilePath([rootDir2], (filePath) => {
+              const item = Array.from(projectView.element.querySelectorAll('li')).find(a => a.textContent.includes(filePath))
+              expect(item).toExist()
+              expect(item.querySelectorAll('div')[1].textContent).toBe(path.join(path.basename(rootDir2), filePath))
+            })
+          })
+
+          it('only creates a single path loader task', async () => {
+            spyOn(PathLoader, 'startTask').andCallThrough()
+
+            await projectView.toggle() // Show
+
+            await projectView.toggle() // Hide
+
+            await projectView.toggle() // Show again
+
+            expect(PathLoader.startTask.callCount).toBe(1)
+          })
+
+          it('puts the last opened path first', async () => {
+            await atom.workspace.open('sample.txt')
+            await atom.workspace.open('sample.js')
+
+            await projectView.toggle()
+
+            await waitForPathsToDisplay(projectView)
+
+            const results = projectView.element.querySelectorAll('li')
+
+            expect(results[0].textContent).toContain('sample.txt')
+            expect(results[results.length - 1].textContent).toContain('sample.html')
+          })
+
+          it('displays paths correctly if the last-opened path is not part of the project (regression)', async () => {
+            await atom.workspace.open('foo.txt')
+            await atom.workspace.open('sample.js')
+
+            await projectView.toggle()
+
+            await waitForPathsToDisplay(projectView)
+          })
+
+          describe('symlinks on #darwin or #linux', () => {
+            let junkDirPath, junkFilePath
+
+            beforeEach(() => {
+              junkDirPath = fs.realpathSync(temp.mkdirSync('junk-1'))
+              junkFilePath = path.join(junkDirPath, 'file.txt')
+              fs.writeFileSync(junkFilePath, 'txt')
+              fs.writeFileSync(path.join(junkDirPath, 'a'), 'txt')
+
+              const brokenFilePath = path.join(junkDirPath, 'delete.txt')
+              fs.writeFileSync(brokenFilePath, 'delete-me')
+
+              fs.symlinkSync(junkFilePath, atom.project.getDirectories()[0].resolve('symlink-to-file'))
+              fs.symlinkSync(junkDirPath, atom.project.getDirectories()[0].resolve('symlink-to-dir'))
+              fs.symlinkSync(brokenFilePath, atom.project.getDirectories()[0].resolve('broken-symlink'))
+
+              fs.symlinkSync(atom.project.getDirectories()[0].resolve('sample.txt'), atom.project.getDirectories()[0].resolve('symlink-to-internal-file'))
+              fs.symlinkSync(atom.project.getDirectories()[0].resolve('dir'), atom.project.getDirectories()[0].resolve('symlink-to-internal-dir'))
+              fs.symlinkSync(atom.project.getDirectories()[0].resolve('..'), atom.project.getDirectories()[0].resolve('symlink-to-project-dir-ancestor'))
+
+              fs.unlinkSync(brokenFilePath)
+            })
+
+            it('indexes project paths that are symlinks', async () => {
+              const symlinkProjectPath = path.join(junkDirPath, 'root-dir-symlink')
+              fs.symlinkSync(atom.project.getPaths()[0], symlinkProjectPath)
+
+              atom.project.setPaths([symlinkProjectPath])
+
+              await projectView.toggle()
+
+              await waitForPathsToDisplay(projectView)
+
+              expect(Array.from(projectView.element.querySelectorAll('li')).find(a => a.textContent.includes('sample.txt'))).toBeDefined()
+            })
+
+            it('includes symlinked file paths', async () => {
+              await projectView.toggle()
+
+              await waitForPathsToDisplay(projectView)
+
+              const results = Array.from(projectView.element.querySelectorAll('li'))
+              const sourceSymlink = results.find(a => a.textContent.includes('symlink-to-internal-file'))
+              const destSymlink = results.find(a => a.textContent.includes('symlink-to-file'))
+
+              expect(destSymlink).toBeDefined()
+
+              // The behaviour when ripgrep is enabled is slightly different.
+              if (useRipGrep) {
+                expect(sourceSymlink).toBeDefined()
+              } else {
+                expect(sourceSymlink).not.toBeDefined()
+              }
+            })
+
+            it('excludes symlinked folder paths if followSymlinks is false', async () => {
+              atom.config.set('core.followSymlinks', false)
+
+              await projectView.toggle()
+
+              await waitForPathsToDisplay(projectView)
+
+              const results = Array.from(projectView.element.querySelectorAll('li'))
+
+              expect(results.find(a => a.textContent.includes('symlink-to-dir'))).not.toBeDefined()
+              expect(results.find(a => a.textContent.includes('symlink-to-dir/a'))).not.toBeDefined()
+              expect(results.find(a => a.textContent.includes('symlink-to-internal-dir'))).not.toBeDefined()
+              expect(results.find(a => a.textContent.includes('symlink-to-internal-dir/a'))).not.toBeDefined()
+            })
+
+            it('includes symlinked folder paths if followSymlinks is true', async () => {
+              atom.config.set('core.followSymlinks', true)
+
+              await projectView.toggle()
+
+              await waitForPathsToDisplay(projectView)
+
+              const results = Array.from(projectView.element.querySelectorAll('li'))
+              const sourceSymlink = results.find(a => a.textContent.includes('symlink-to-internal-dir/a'))
+              const destSymlink = results.find(a => a.textContent.includes('symlink-to-dir/a'))
+
+              expect(destSymlink).toBeDefined()
+
+              // The behaviour when ripgrep is enabled is slightly different.
+              if (useRipGrep) {
+                expect(sourceSymlink).toBeDefined()
+              } else {
+                expect(sourceSymlink).not.toBeDefined()
+              }
+            })
+          })
+
+          describe('socket files on #darwin or #linux', () => {
+            let socketServer, socketPath
+
+            beforeEach(() => {
+              socketServer = net.createServer(() => {})
+              socketPath = path.join(rootDir1, 'some.sock')
+              waitsFor(done => socketServer.listen(socketPath, done))
+            })
+
+            afterEach(() => socketServer.close())
+
+            it('does not interfere with ability to load files', async () => {
+              await projectView.toggle()
+
+              await waitForPathsToDisplay(projectView)
+              expect(Array.from(projectView.element.querySelectorAll('li')).find(a => a.textContent.includes('a'))).toBeDefined()
+              expect(Array.from(projectView.element.querySelectorAll('li')).find(a => a.textContent.includes('some.sock'))).not.toBeDefined()
+            })
+          })
+
+          it('ignores paths that match entries in config.fuzzy-finder.ignoredNames', async () => {
+            atom.config.set('fuzzy-finder.ignoredNames', ['sample.js', '*.txt'])
+
+            await projectView.toggle()
+
+            await waitForPathsToDisplay(projectView)
+
+            expect(Array.from(projectView.element.querySelectorAll('li')).find(a => a.textContent.includes('sample.js'))).not.toBeDefined()
+            expect(Array.from(projectView.element.querySelectorAll('li')).find(a => a.textContent.includes('sample.txt'))).not.toBeDefined()
+            expect(Array.from(projectView.element.querySelectorAll('li')).find(a => a.textContent.includes('a'))).toBeDefined()
+          })
+
+          it("only shows a given path once, even if it's within multiple root folders", async () => {
+            const childDir1 = path.join(rootDir1, 'a-child')
+            const childFile1 = path.join(childDir1, 'child-file.txt')
+            fs.mkdirSync(childDir1)
+            fs.writeFileSync(childFile1, 'stuff')
+            atom.project.addPath(childDir1)
+
+            await projectView.toggle()
+
+            await waitForPathsToDisplay(projectView)
+
+            expect(Array.from(projectView.element.querySelectorAll('li')).filter(a => a.textContent.includes('child-file.txt')).length).toBe(1)
+          })
+        })
+
+        describe('when the project only has one path', () => {
+          beforeEach(() => atom.project.setPaths([rootDir1]))
+
+          it("doesn't show the name of each file's root directory", async () => {
+            await projectView.toggle()
+
+            await waitForPathsToDisplay(projectView)
+
+            const items = Array.from(projectView.element.querySelectorAll('li'))
+            eachFilePath([rootDir1], (filePath) => {
+              const item = items.find(a => a.textContent.includes(filePath))
+              expect(item).toExist()
+              expect(item).not.toHaveText(path.basename(rootDir1))
+            })
+          })
+        })
+
+        describe('when the project has no path', () => {
+          beforeEach(() => {
+            jasmine.attachToDOM(workspaceElement)
+            atom.project.setPaths([])
+          })
+
+          it('shows an empty message with no files in the list', async () => {
+            await projectView.toggle()
+
+            expect(projectView.selectListView.refs.emptyMessage).toBeVisible()
+            expect(projectView.selectListView.refs.emptyMessage.textContent).toBe('Project is empty')
+            expect(projectView.element.querySelectorAll('li').length).toBe(0)
+          })
+        })
+      })
+
+      describe("when a project's root path is unlinked", () => {
+        beforeEach(() => {
+          if (fs.existsSync(rootDir1)) { rmrf(rootDir1) }
+          if (fs.existsSync(rootDir2)) { rmrf(rootDir2) }
+        })
+
+        it('posts an error notification', async () => {
+          spyOn(atom.notifications, 'addError')
+          await projectView.toggle()
+
+          await conditionPromise(() => atom.workspace.panelForItem(projectView).isVisible())
+          expect(atom.notifications.addError).toHaveBeenCalled()
+        })
+      })
+
+      describe('when a path selection is confirmed', () => {
+        it('opens the file associated with that path in that split', async () => {
+          jasmine.attachToDOM(workspaceElement)
+          const editor1 = atom.workspace.getActiveTextEditor()
+          atom.workspace.getActivePane().splitRight({copyActiveItem: true})
+          const editor2 = atom.workspace.getActiveTextEditor()
+          const expectedPath = atom.project.getDirectories()[0].resolve('dir/a')
+
+          await projectView.toggle()
+
+          projectView.confirm({uri: expectedPath})
+
+          await conditionPromise(() => atom.workspace.getActivePane().getItems().length === 2)
+
+          const editor3 = atom.workspace.getActiveTextEditor()
+          expect(atom.workspace.panelForItem(projectView).isVisible()).toBe(false)
           expect(editor1.getPath()).not.toBe(expectedPath)
           expect(editor2.getPath()).not.toBe(expectedPath)
           expect(editor3.getPath()).toBe(expectedPath)
           expect(atom.views.getView(editor3)).toHaveFocus()
         })
-      )
 
-      describe('when the active pane does not have an item for the selected path and fuzzy-finder.searchAllPanes is false', () =>
-        it('adds a new item to the active pane for the selected path', async () => {
-          const expectedPath = atom.project.getDirectories()[0].resolve('sample.txt')
+        describe('when the selected path is a directory', () =>
+          it("leaves the the tree view open, doesn't open the path in the editor, and displays an error", async () => {
+            jasmine.attachToDOM(workspaceElement)
+            const editorPath = atom.workspace.getActiveTextEditor().getPath()
+            await projectView.toggle()
 
-          await bufferView.toggle()
+            projectView.confirm({uri: atom.project.getDirectories()[0].resolve('dir')})
+            expect(projectView.element.parentElement).toBeDefined()
+            expect(atom.workspace.getActiveTextEditor().getPath()).toBe(editorPath)
 
-          atom.views.getView(editor1).focus()
+            await conditionPromise(() => projectView.selectListView.refs.errorMessage)
 
-          await bufferView.toggle()
+            jasmine.useMockClock()
 
-          expect(atom.workspace.getActiveTextEditor()).toBe(editor1)
-          bufferView.confirm({uri: expectedPath}, atom.config.get('fuzzy-finder.searchAllPanes'))
+            advanceClock(2000)
 
-          await conditionPromise(() => atom.workspace.getActivePane().getItems().length === 2)
+            await conditionPromise(() => !projectView.selectListView.refs.errorMessage)
+          })
+        )
+      })
+    })
 
-          const editor4 = atom.workspace.getActiveTextEditor()
+    describe('buffer-finder behavior', () => {
+      describe('toggling', () => {
+        describe('when there are pane items with paths', () => {
+          beforeEach(async () => {
+            jasmine.attachToDOM(workspaceElement)
 
-          expect(atom.workspace.panelForItem(bufferView).isVisible()).toBe(false)
+            await atom.workspace.open('sample.txt')
+          })
 
-          expect(editor4).not.toBe(editor1)
-          expect(editor4).not.toBe(editor2)
-          expect(editor4).not.toBe(editor3)
+          it("shows the FuzzyFinder if it isn't showing, or hides it and returns focus to the active editor", async () => {
+            expect(atom.workspace.panelForItem(bufferView)).toBeNull()
+            atom.workspace.getActivePane().splitRight({copyActiveItem: true})
+            const [editor1, editor2, editor3] = atom.workspace.getTextEditors() // eslint-disable-line no-unused-vars
+            expect(atom.workspace.getActivePaneItem()).toBe(editor3)
 
-          expect(editor4.getPath()).toBe(expectedPath)
-          expect(atom.views.getView(editor4)).toHaveFocus()
+            expect(atom.views.getView(editor3)).toHaveFocus()
+
+            await bufferView.toggle()
+
+            expect(atom.workspace.panelForItem(bufferView).isVisible()).toBe(true)
+            expect(workspaceElement.querySelector('.fuzzy-finder')).toHaveFocus()
+            bufferView.selectListView.refs.queryEditor.insertText('this should not show up next time we toggle')
+
+            await bufferView.toggle()
+
+            expect(atom.views.getView(editor3)).toHaveFocus()
+            expect(atom.workspace.panelForItem(bufferView).isVisible()).toBe(false)
+
+            await bufferView.toggle()
+
+            expect(bufferView.selectListView.refs.queryEditor.getText()).toBe('')
+          })
+
+          it('lists the paths of the current items, sorted by most recently opened but with the current item last', async () => {
+            await atom.workspace.open('sample-with-tabs.coffee')
+
+            await bufferView.toggle()
+
+            expect(atom.workspace.panelForItem(bufferView).isVisible()).toBe(true)
+            expect(Array.from(bufferView.element.querySelectorAll('li > div.file')).map(e => e.textContent)).toEqual(['sample.txt', 'sample.js', 'sample-with-tabs.coffee'])
+
+            await bufferView.toggle()
+
+            expect(atom.workspace.panelForItem(bufferView).isVisible()).toBe(false)
+
+            await atom.workspace.open('sample.txt')
+
+            await bufferView.toggle()
+
+            expect(atom.workspace.panelForItem(bufferView).isVisible()).toBe(true)
+            expect(Array.from(bufferView.element.querySelectorAll('li > div.file')).map(e => e.textContent)).toEqual(['sample-with-tabs.coffee', 'sample.js', 'sample.txt'])
+            expect(bufferView.element.querySelector('li')).toHaveClass('selected')
+          })
+
+          it('serializes the list of paths and their last opened time', async () => {
+            await atom.workspace.open('sample-with-tabs.coffee')
+
+            await bufferView.toggle()
+
+            await atom.workspace.open('sample.js')
+
+            await bufferView.toggle()
+
+            await atom.workspace.open()
+
+            await atom.packages.deactivatePackage('fuzzy-finder')
+
+            let states = _.map(atom.packages.getPackageState('fuzzy-finder'), (path, time) => [path, time])
+            expect(states.length).toBe(3)
+            states = _.sortBy(states, (path, time) => -time)
+
+            const paths = ['sample-with-tabs.coffee', 'sample.txt', 'sample.js']
+
+            for (let [time, bufferPath] of states) {
+              expect(_.last(bufferPath.split(path.sep))).toBe(paths.shift())
+              expect(time).toBeGreaterThan(50000)
+            }
+          })
         })
+
+        describe('when there are only panes with anonymous items', () =>
+          it('does not open', async () => {
+            atom.workspace.getActivePane().destroy()
+            await atom.workspace.open()
+
+            await bufferView.toggle()
+
+            expect(atom.workspace.panelForItem(bufferView)).toBeNull()
+          })
+        )
+
+        describe('when there are no pane items', () =>
+          it('does not open', async () => {
+            atom.workspace.getActivePane().destroy()
+            await bufferView.toggle()
+
+            expect(atom.workspace.panelForItem(bufferView)).toBeNull()
+          })
+        )
+
+        describe('when multiple sessions are opened on the same path', () =>
+          it('does not display duplicates for that path in the list', async () => {
+            await atom.workspace.open('sample.js')
+
+            atom.workspace.getActivePane().splitRight({copyActiveItem: true})
+
+            await bufferView.toggle()
+
+            expect(Array.from(bufferView.element.querySelectorAll('li > div.file')).map(e => e.textContent)).toEqual(['sample.js'])
+          })
       )
+      })
 
-      describe('when the active pane does not have an item for the selected path and fuzzy-finder.searchAllPanes is true', () => {
-        beforeEach(() => atom.config.set('fuzzy-finder.searchAllPanes', true))
+      describe('when a path selection is confirmed', () => {
+        let editor1, editor2, editor3
 
-        it('switches to the pane with the item for the selected path', async () => {
-          const expectedPath = atom.project.getDirectories()[0].resolve('sample.txt')
-          let originalPane = null
+        beforeEach(async () => {
+          jasmine.attachToDOM(workspaceElement)
+          atom.workspace.getActivePane().splitRight({copyActiveItem: true})
 
-          await bufferView.toggle()
+          await atom.workspace.open('sample.txt');
 
-          atom.views.getView(editor1).focus()
-          originalPane = atom.workspace.getActivePane()
+          [editor1, editor2, editor3] = atom.workspace.getTextEditors()
 
-          await bufferView.toggle()
-
-          expect(atom.workspace.getActiveTextEditor()).toBe(editor1)
-          bufferView.confirm({uri: expectedPath}, {searchAllPanes: atom.config.get('fuzzy-finder.searchAllPanes')})
-
-          await conditionPromise(() => atom.workspace.getActiveTextEditor().getPath() === expectedPath)
-
-          expect(atom.workspace.panelForItem(bufferView).isVisible()).toBe(false)
-          expect(atom.workspace.getActivePane()).not.toBe(originalPane)
           expect(atom.workspace.getActiveTextEditor()).toBe(editor3)
-          expect(atom.workspace.getPaneItems().length).toBe(3)
+
+          atom.commands.dispatch(atom.views.getView(editor2), 'pane:show-previous-item')
+
+          await bufferView.toggle()
+        })
+
+        describe('when the active pane has an item for the selected path', () =>
+          it('switches to the item for the selected path', async () => {
+            const expectedPath = atom.project.getDirectories()[0].resolve('sample.txt')
+            bufferView.confirm({uri: expectedPath})
+
+            await conditionPromise(() => atom.workspace.getActiveTextEditor().getPath() === expectedPath)
+
+            expect(atom.workspace.panelForItem(bufferView).isVisible()).toBe(false)
+            expect(editor1.getPath()).not.toBe(expectedPath)
+            expect(editor2.getPath()).not.toBe(expectedPath)
+            expect(editor3.getPath()).toBe(expectedPath)
+            expect(atom.views.getView(editor3)).toHaveFocus()
+          })
+        )
+
+        describe('when the active pane does not have an item for the selected path and fuzzy-finder.searchAllPanes is false', () =>
+          it('adds a new item to the active pane for the selected path', async () => {
+            const expectedPath = atom.project.getDirectories()[0].resolve('sample.txt')
+
+            await bufferView.toggle()
+
+            atom.views.getView(editor1).focus()
+
+            await bufferView.toggle()
+
+            expect(atom.workspace.getActiveTextEditor()).toBe(editor1)
+            bufferView.confirm({uri: expectedPath}, atom.config.get('fuzzy-finder.searchAllPanes'))
+
+            await conditionPromise(() => atom.workspace.getActivePane().getItems().length === 2)
+
+            const editor4 = atom.workspace.getActiveTextEditor()
+
+            expect(atom.workspace.panelForItem(bufferView).isVisible()).toBe(false)
+
+            expect(editor4).not.toBe(editor1)
+            expect(editor4).not.toBe(editor2)
+            expect(editor4).not.toBe(editor3)
+
+            expect(editor4.getPath()).toBe(expectedPath)
+            expect(atom.views.getView(editor4)).toHaveFocus()
+          })
+        )
+
+        describe('when the active pane does not have an item for the selected path and fuzzy-finder.searchAllPanes is true', () => {
+          beforeEach(() => atom.config.set('fuzzy-finder.searchAllPanes', true))
+
+          it('switches to the pane with the item for the selected path', async () => {
+            const expectedPath = atom.project.getDirectories()[0].resolve('sample.txt')
+            let originalPane = null
+
+            await bufferView.toggle()
+
+            atom.views.getView(editor1).focus()
+            originalPane = atom.workspace.getActivePane()
+
+            await bufferView.toggle()
+
+            expect(atom.workspace.getActiveTextEditor()).toBe(editor1)
+            bufferView.confirm({uri: expectedPath}, {searchAllPanes: atom.config.get('fuzzy-finder.searchAllPanes')})
+
+            await conditionPromise(() => atom.workspace.getActiveTextEditor().getPath() === expectedPath)
+
+            expect(atom.workspace.panelForItem(bufferView).isVisible()).toBe(false)
+            expect(atom.workspace.getActivePane()).not.toBe(originalPane)
+            expect(atom.workspace.getActiveTextEditor()).toBe(editor3)
+            expect(atom.workspace.getPaneItems().length).toBe(3)
+          })
         })
       })
     })
-  })
 
-  describe('common behavior between file and buffer finder', () =>
-    describe('when the fuzzy finder is cancelled', () => {
-      describe('when an editor is open', () =>
-        it('detaches the finder and focuses the previously focused element', async () => {
-          jasmine.attachToDOM(workspaceElement)
-          const activeEditor = atom.workspace.getActiveTextEditor()
+    describe('common behavior between file and buffer finder', () =>
+      describe('when the fuzzy finder is cancelled', () => {
+        describe('when an editor is open', () =>
+          it('detaches the finder and focuses the previously focused element', async () => {
+            jasmine.attachToDOM(workspaceElement)
+            const activeEditor = atom.workspace.getActiveTextEditor()
 
-          await projectView.toggle()
+            await projectView.toggle()
 
-          expect(projectView.element.parentElement).toBeDefined()
-          expect(projectView.selectListView.refs.queryEditor.element).toHaveFocus()
+            expect(projectView.element.parentElement).toBeDefined()
+            expect(projectView.selectListView.refs.queryEditor.element).toHaveFocus()
 
-          projectView.cancel()
+            projectView.cancel()
 
-          expect(atom.workspace.panelForItem(projectView).isVisible()).toBe(false)
-          expect(atom.views.getView(activeEditor)).toHaveFocus()
+            expect(atom.workspace.panelForItem(projectView).isVisible()).toBe(false)
+            expect(atom.views.getView(activeEditor)).toHaveFocus()
+          })
+        )
+
+        describe('when no editors are open', () =>
+          it('detaches the finder and focuses the previously focused element', async () => {
+            jasmine.attachToDOM(workspaceElement)
+            atom.workspace.getActivePane().destroy()
+
+            const inputView = document.createElement('input')
+            workspaceElement.appendChild(inputView)
+            inputView.focus()
+
+            await projectView.toggle()
+
+            expect(projectView.element.parentElement).toBeDefined()
+            expect(projectView.selectListView.refs.queryEditor.element).toHaveFocus()
+            projectView.cancel()
+            expect(atom.workspace.panelForItem(projectView).isVisible()).toBe(false)
+            expect(inputView).toHaveFocus()
+          })
+        )
+      })
+    )
+
+    describe('cached file paths', () => {
+      beforeEach(() => {
+        spyOn(PathLoader, 'startTask').andCallThrough()
+        spyOn(atom.workspace, 'getTextEditors').andCallThrough()
+      })
+
+      it('caches file paths after first time', async () => {
+        await projectView.toggle()
+
+        await waitForPathsToDisplay(projectView)
+
+        expect(PathLoader.startTask).toHaveBeenCalled()
+        PathLoader.startTask.reset()
+
+        await projectView.toggle()
+
+        await projectView.toggle()
+
+        await waitForPathsToDisplay(projectView)
+
+        expect(PathLoader.startTask).not.toHaveBeenCalled()
+      })
+
+      it("doesn't cache buffer paths", async () => {
+        await bufferView.toggle()
+
+        await waitForPathsToDisplay(bufferView)
+
+        expect(atom.workspace.getTextEditors).toHaveBeenCalled()
+        atom.workspace.getTextEditors.reset()
+
+        await bufferView.toggle()
+
+        await bufferView.toggle()
+
+        await waitForPathsToDisplay(bufferView)
+
+        expect(atom.workspace.getTextEditors).toHaveBeenCalled()
+      })
+
+      it('busts the cache when the window gains focus', async () => {
+        await projectView.toggle()
+
+        await waitForPathsToDisplay(projectView)
+
+        expect(PathLoader.startTask).toHaveBeenCalled()
+        PathLoader.startTask.reset()
+        window.dispatchEvent(new CustomEvent('focus'))
+        await projectView.toggle()
+
+        await projectView.toggle()
+
+        expect(PathLoader.startTask).toHaveBeenCalled()
+      })
+
+      it('busts the cache when the project path changes', async () => {
+        await projectView.toggle()
+
+        await waitForPathsToDisplay(projectView)
+
+        expect(PathLoader.startTask).toHaveBeenCalled()
+        PathLoader.startTask.reset()
+        atom.project.setPaths([temp.mkdirSync('atom')])
+
+        await projectView.toggle()
+
+        await projectView.toggle()
+
+        expect(PathLoader.startTask).toHaveBeenCalled()
+        expect(projectView.element.querySelectorAll('li').length).toBe(0)
+      })
+
+      describe('the initial load paths task started during package activation', () => {
+        beforeEach(async () => {
+          fuzzyFinder.projectView.destroy()
+          fuzzyFinder.projectView = null
+          fuzzyFinder.startLoadPathsTask()
+
+          await conditionPromise(() => fuzzyFinder.projectPaths)
         })
-      )
 
-      describe('when no editors are open', () =>
-        it('detaches the finder and focuses the previously focused element', async () => {
-          jasmine.attachToDOM(workspaceElement)
-          atom.workspace.getActivePane().destroy()
-
-          const inputView = document.createElement('input')
-          workspaceElement.appendChild(inputView)
-          inputView.focus()
-
-          await projectView.toggle()
-
-          expect(projectView.element.parentElement).toBeDefined()
-          expect(projectView.selectListView.refs.queryEditor.element).toHaveFocus()
-          projectView.cancel()
-          expect(atom.workspace.panelForItem(projectView).isVisible()).toBe(false)
-          expect(inputView).toHaveFocus()
+        it('passes the indexed paths into the project view when it is created', () => {
+          const {projectPaths} = fuzzyFinder
+          expect(projectPaths.length).toBe(19)
+          projectView = fuzzyFinder.createProjectView()
+          expect(projectView.paths).toBe(projectPaths)
+          expect(projectView.reloadPaths).toBe(false)
         })
-      )
-    })
-  )
 
-  describe('cached file paths', () => {
-    beforeEach(() => {
-      spyOn(PathLoader, 'startTask').andCallThrough()
-      spyOn(atom.workspace, 'getTextEditors').andCallThrough()
-    })
+        it('busts the cached paths when the project paths change', () => {
+          atom.project.setPaths([])
 
-    it('caches file paths after first time', async () => {
-      await projectView.toggle()
+          const {projectPaths} = fuzzyFinder
+          expect(projectPaths).toBe(null)
 
-      await waitForPathsToDisplay(projectView)
-
-      expect(PathLoader.startTask).toHaveBeenCalled()
-      PathLoader.startTask.reset()
-
-      await projectView.toggle()
-
-      await projectView.toggle()
-
-      await waitForPathsToDisplay(projectView)
-
-      expect(PathLoader.startTask).not.toHaveBeenCalled()
+          projectView = fuzzyFinder.createProjectView()
+          expect(projectView.paths).toBe(null)
+          expect(projectView.reloadPaths).toBe(true)
+        })
+      })
     })
 
-    it("doesn't cache buffer paths", async () => {
-      await bufferView.toggle()
+    describe('opening a path into a split', () => {
+      it('opens the path by splitting the active editor left', async () => {
+        expect(atom.workspace.getCenter().getPanes().length).toBe(1)
+        let filePath = null
 
-      await waitForPathsToDisplay(bufferView)
+        await bufferView.toggle();
 
-      expect(atom.workspace.getTextEditors).toHaveBeenCalled()
-      atom.workspace.getTextEditors.reset()
+        ({filePath} = bufferView.selectListView.getSelectedItem())
+        atom.commands.dispatch(bufferView.element, 'pane:split-left')
 
-      await bufferView.toggle()
+        await conditionPromise(() => atom.workspace.getCenter().getPanes().length === 2)
 
-      await bufferView.toggle()
+        await conditionPromise(() => atom.workspace.getActiveTextEditor())
 
-      await waitForPathsToDisplay(bufferView)
+        const [leftPane, rightPane] = atom.workspace.getCenter().getPanes() // eslint-disable-line no-unused-vars
+        expect(atom.workspace.getActivePane()).toBe(leftPane)
+        expect(atom.workspace.getActiveTextEditor().getPath()).toBe(atom.project.getDirectories()[0].resolve(filePath))
+      })
 
-      expect(atom.workspace.getTextEditors).toHaveBeenCalled()
+      it('opens the path by splitting the active editor right', async () => {
+        expect(atom.workspace.getCenter().getPanes().length).toBe(1)
+        let filePath = null
+
+        await bufferView.toggle();
+
+        ({filePath} = bufferView.selectListView.getSelectedItem())
+        atom.commands.dispatch(bufferView.element, 'pane:split-right')
+
+        await conditionPromise(() => atom.workspace.getCenter().getPanes().length === 2)
+
+        await conditionPromise(() => atom.workspace.getActiveTextEditor())
+
+        const [leftPane, rightPane] = atom.workspace.getCenter().getPanes() // eslint-disable-line no-unused-vars
+        expect(atom.workspace.getActivePane()).toBe(rightPane)
+        expect(atom.workspace.getActiveTextEditor().getPath()).toBe(atom.project.getDirectories()[0].resolve(filePath))
+      })
+
+      it('opens the path by splitting the active editor up', async () => {
+        expect(atom.workspace.getCenter().getPanes().length).toBe(1)
+        let filePath = null
+
+        await bufferView.toggle();
+
+        ({filePath} = bufferView.selectListView.getSelectedItem())
+        atom.commands.dispatch(bufferView.element, 'pane:split-up')
+
+        await conditionPromise(() => atom.workspace.getCenter().getPanes().length === 2)
+
+        await conditionPromise(() => atom.workspace.getActiveTextEditor())
+
+        const [topPane, bottomPane] = atom.workspace.getCenter().getPanes() // eslint-disable-line no-unused-vars
+        expect(atom.workspace.getActivePane()).toBe(topPane)
+        expect(atom.workspace.getActiveTextEditor().getPath()).toBe(atom.project.getDirectories()[0].resolve(filePath))
+      })
+
+      it('opens the path by splitting the active editor down', async () => {
+        expect(atom.workspace.getCenter().getPanes().length).toBe(1)
+        let filePath = null
+
+        await bufferView.toggle();
+
+        ({filePath} = bufferView.selectListView.getSelectedItem())
+        atom.commands.dispatch(bufferView.element, 'pane:split-down')
+
+        await conditionPromise(() => atom.workspace.getCenter().getPanes().length === 2)
+
+        await conditionPromise(() => atom.workspace.getActiveTextEditor())
+
+        const [topPane, bottomPane] = atom.workspace.getCenter().getPanes() // eslint-disable-line no-unused-vars
+        expect(atom.workspace.getActivePane()).toBe(bottomPane)
+        expect(atom.workspace.getActiveTextEditor().getPath()).toBe(atom.project.getDirectories()[0].resolve(filePath))
+      })
     })
 
-    it('busts the cache when the window gains focus', async () => {
-      await projectView.toggle()
-
-      await waitForPathsToDisplay(projectView)
-
-      expect(PathLoader.startTask).toHaveBeenCalled()
-      PathLoader.startTask.reset()
-      window.dispatchEvent(new CustomEvent('focus'))
-      await projectView.toggle()
-
-      await projectView.toggle()
-
-      expect(PathLoader.startTask).toHaveBeenCalled()
-    })
-
-    it('busts the cache when the project path changes', async () => {
-      await projectView.toggle()
-
-      await waitForPathsToDisplay(projectView)
-
-      expect(PathLoader.startTask).toHaveBeenCalled()
-      PathLoader.startTask.reset()
-      atom.project.setPaths([temp.mkdirSync('atom')])
-
-      await projectView.toggle()
-
-      await projectView.toggle()
-
-      expect(PathLoader.startTask).toHaveBeenCalled()
-      expect(projectView.element.querySelectorAll('li').length).toBe(0)
-    })
-
-    describe('the initial load paths task started during package activation', () => {
+    describe('when the query contains a colon', () => {
       beforeEach(async () => {
-        fuzzyFinder.projectView.destroy()
-        fuzzyFinder.projectView = null
-        fuzzyFinder.startLoadPathsTask()
+        jasmine.attachToDOM(workspaceElement)
+        expect(atom.workspace.panelForItem(projectView)).toBeNull()
 
-        await conditionPromise(() => fuzzyFinder.projectPaths)
+        await atom.workspace.open('sample.txt')
+
+        const [editor1, editor2] = atom.workspace.getTextEditors()
+        editor1.setCursorBufferPosition([8, 3])
+        expect(atom.workspace.getActiveTextEditor()).toBe(editor2)
+        expect(editor1.getCursorBufferPosition()).toEqual([8, 3])
       })
 
-      it('passes the indexed paths into the project view when it is created', () => {
-        const {projectPaths} = fuzzyFinder
-        expect(projectPaths.length).toBe(19)
-        projectView = fuzzyFinder.createProjectView()
-        expect(projectView.paths).toBe(projectPaths)
-        expect(projectView.reloadPaths).toBe(false)
+      describe('when the colon is followed by numbers', () => {
+        describe('when the numbers are not followed by another colon', () => {
+          describe('when the filter text has a file path', () => {
+            it('opens the selected path to that line number', async () => {
+              const [editor1, editor2] = atom.workspace.getTextEditors() // eslint-disable-line no-unused-vars
+
+              await bufferView.toggle()
+
+              expect(atom.workspace.panelForItem(bufferView).isVisible()).toBe(true)
+              bufferView.selectListView.refs.queryEditor.setText('sample.js:4')
+
+              await getOrScheduleUpdatePromise()
+
+              const {filePath} = bufferView.selectListView.getSelectedItem()
+              expect(atom.project.getDirectories()[0].resolve(filePath)).toBe(editor1.getPath())
+
+              spyOn(bufferView, 'moveToCaretPosition').andCallThrough()
+              atom.commands.dispatch(bufferView.element, 'core:confirm')
+
+              await conditionPromise(() => bufferView.moveToCaretPosition.callCount > 0)
+
+              expect(atom.workspace.getActiveTextEditor()).toBe(editor1)
+              expect(editor1.getCursorBufferPosition()).toEqual([3, 4])
+            })
+          })
+
+          describe("when the filter text doesn't have a file path", () => {
+            it('moves the cursor in the active editor to that line number', async () => {
+              const [editor1, editor2] = atom.workspace.getTextEditors() // eslint-disable-line no-unused-vars
+
+              await atom.workspace.open('sample.js')
+
+              expect(atom.workspace.getActiveTextEditor()).toBe(editor1)
+
+              await bufferView.toggle()
+
+              expect(atom.workspace.panelForItem(bufferView).isVisible()).toBe(true)
+              bufferView.selectListView.refs.queryEditor.insertText(':4')
+
+              await getOrScheduleUpdatePromise()
+
+              expect(bufferView.element.querySelectorAll('li').length).toBe(0)
+              spyOn(bufferView, 'moveToCaretPosition').andCallThrough()
+              atom.commands.dispatch(bufferView.element, 'core:confirm')
+
+              await conditionPromise(() => bufferView.moveToCaretPosition.callCount > 0)
+
+              expect(atom.workspace.getActiveTextEditor()).toBe(editor1)
+              expect(editor1.getCursorBufferPosition()).toEqual([3, 4])
+            })
+          })
+        })
+
+        describe('when the numbers are followed by another colon', () => {
+          describe('when the colon is followed by more numbers', () => {
+            describe('when the filter text has a file path', () => {
+              it('opens the selected path to that line number and column', async () => {
+                const [editor1, editor2] = atom.workspace.getTextEditors() // eslint-disable-line no-unused-vars
+
+                await bufferView.toggle()
+
+                expect(atom.workspace.panelForItem(bufferView).isVisible()).toBe(true)
+                bufferView.selectListView.refs.queryEditor.setText('sample.js:4:6')
+
+                await getOrScheduleUpdatePromise()
+
+                const {filePath} = bufferView.selectListView.getSelectedItem()
+                expect(atom.project.getDirectories()[0].resolve(filePath)).toBe(editor1.getPath())
+
+                spyOn(bufferView, 'moveToCaretPosition').andCallThrough()
+                atom.commands.dispatch(bufferView.element, 'core:confirm')
+
+                await conditionPromise(() => bufferView.moveToCaretPosition.callCount > 0)
+
+                expect(atom.workspace.getActiveTextEditor()).toBe(editor1)
+                expect(editor1.getCursorBufferPosition()).toEqual([3, 6])
+              })
+            })
+
+            describe("when the filter text doesn't have a file path", () => {
+              it('moves the cursor in the active editor to that line number and column', async () => {
+                const [editor1, editor2] = atom.workspace.getTextEditors() // eslint-disable-line no-unused-vars
+
+                await atom.workspace.open('sample.js')
+
+                expect(atom.workspace.getActiveTextEditor()).toBe(editor1)
+
+                await bufferView.toggle()
+
+                expect(atom.workspace.panelForItem(bufferView).isVisible()).toBe(true)
+                bufferView.selectListView.refs.queryEditor.insertText(':4:6')
+
+                await getOrScheduleUpdatePromise()
+
+                expect(bufferView.selectListView.refs.emptyMessage.innerText).toEqual(
+                  'Jump to line and column in active editor'
+                )
+                expect(bufferView.element.querySelectorAll('li').length).toBe(0)
+                spyOn(bufferView, 'moveToCaretPosition').andCallThrough()
+                atom.commands.dispatch(bufferView.element, 'core:confirm')
+
+                await conditionPromise(() => bufferView.moveToCaretPosition.callCount > 0)
+
+                expect(atom.workspace.getActiveTextEditor()).toBe(editor1)
+                expect(editor1.getCursorBufferPosition()).toEqual([3, 6])
+              })
+            })
+          })
+
+          describe('when the colon is not followed by more numbers', () => {
+            describe('when the filter text has a file path', () => {
+              it('opens the file, jumps to the first character of the line and does not throw an error', async () => {
+                const [editor1, editor2] = atom.workspace.getTextEditors() // eslint-disable-line no-unused-vars
+
+                await bufferView.toggle()
+
+                expect(atom.workspace.panelForItem(bufferView).isVisible()).toBe(true)
+                bufferView.selectListView.refs.queryEditor.setText('sample.js:5:a')
+
+                await getOrScheduleUpdatePromise()
+
+                const {filePath} = bufferView.selectListView.getSelectedItem()
+                expect(atom.project.getDirectories()[0].resolve(filePath)).toBe(editor1.getPath())
+
+                spyOn(bufferView, 'moveToCaretPosition').andCallThrough()
+                atom.commands.dispatch(bufferView.element, 'core:confirm')
+
+                await conditionPromise(() => bufferView.moveToCaretPosition.callCount > 0)
+
+                expect(atom.workspace.getActiveTextEditor()).toBe(editor1)
+                expect(editor1.getCursorBufferPosition()).toEqual([4, 4])
+              })
+            })
+
+            describe("when the filter text doesn't have a file path", () => {
+              it('jumps to the first character of the line and does not throw an error', async () => {
+                const [editor1, editor2] = atom.workspace.getTextEditors() // eslint-disable-line no-unused-vars
+
+                await atom.workspace.open('sample.js')
+
+                expect(atom.workspace.getActiveTextEditor()).toBe(editor1)
+
+                await bufferView.toggle()
+
+                expect(atom.workspace.panelForItem(bufferView).isVisible()).toBe(true)
+                bufferView.selectListView.refs.queryEditor.setText(':5:a')
+
+                await getOrScheduleUpdatePromise()
+
+                spyOn(bufferView, 'moveToCaretPosition').andCallThrough()
+                atom.commands.dispatch(bufferView.element, 'core:confirm')
+
+                await conditionPromise(() => bufferView.moveToCaretPosition.callCount > 0)
+
+                expect(atom.workspace.getActiveTextEditor()).toBe(editor1)
+                expect(editor1.getCursorBufferPosition()).toEqual([4, 4])
+              })
+            })
+          })
+        })
       })
 
-      it('busts the cached paths when the project paths change', () => {
-        atom.project.setPaths([])
-
-        const {projectPaths} = fuzzyFinder
-        expect(projectPaths).toBe(null)
-
-        projectView = fuzzyFinder.createProjectView()
-        expect(projectView.paths).toBe(null)
-        expect(projectView.reloadPaths).toBe(true)
-      })
-    })
-  })
-
-  describe('opening a path into a split', () => {
-    it('opens the path by splitting the active editor left', async () => {
-      expect(atom.workspace.getCenter().getPanes().length).toBe(1)
-      let filePath = null
-
-      await bufferView.toggle();
-
-      ({filePath} = bufferView.selectListView.getSelectedItem())
-      atom.commands.dispatch(bufferView.element, 'pane:split-left')
-
-      await conditionPromise(() => atom.workspace.getCenter().getPanes().length === 2)
-
-      await conditionPromise(() => atom.workspace.getActiveTextEditor())
-
-      const [leftPane, rightPane] = atom.workspace.getCenter().getPanes() // eslint-disable-line no-unused-vars
-      expect(atom.workspace.getActivePane()).toBe(leftPane)
-      expect(atom.workspace.getActiveTextEditor().getPath()).toBe(atom.project.getDirectories()[0].resolve(filePath))
-    })
-
-    it('opens the path by splitting the active editor right', async () => {
-      expect(atom.workspace.getCenter().getPanes().length).toBe(1)
-      let filePath = null
-
-      await bufferView.toggle();
-
-      ({filePath} = bufferView.selectListView.getSelectedItem())
-      atom.commands.dispatch(bufferView.element, 'pane:split-right')
-
-      await conditionPromise(() => atom.workspace.getCenter().getPanes().length === 2)
-
-      await conditionPromise(() => atom.workspace.getActiveTextEditor())
-
-      const [leftPane, rightPane] = atom.workspace.getCenter().getPanes() // eslint-disable-line no-unused-vars
-      expect(atom.workspace.getActivePane()).toBe(rightPane)
-      expect(atom.workspace.getActiveTextEditor().getPath()).toBe(atom.project.getDirectories()[0].resolve(filePath))
-    })
-
-    it('opens the path by splitting the active editor up', async () => {
-      expect(atom.workspace.getCenter().getPanes().length).toBe(1)
-      let filePath = null
-
-      await bufferView.toggle();
-
-      ({filePath} = bufferView.selectListView.getSelectedItem())
-      atom.commands.dispatch(bufferView.element, 'pane:split-up')
-
-      await conditionPromise(() => atom.workspace.getCenter().getPanes().length === 2)
-
-      await conditionPromise(() => atom.workspace.getActiveTextEditor())
-
-      const [topPane, bottomPane] = atom.workspace.getCenter().getPanes() // eslint-disable-line no-unused-vars
-      expect(atom.workspace.getActivePane()).toBe(topPane)
-      expect(atom.workspace.getActiveTextEditor().getPath()).toBe(atom.project.getDirectories()[0].resolve(filePath))
-    })
-
-    it('opens the path by splitting the active editor down', async () => {
-      expect(atom.workspace.getCenter().getPanes().length).toBe(1)
-      let filePath = null
-
-      await bufferView.toggle();
-
-      ({filePath} = bufferView.selectListView.getSelectedItem())
-      atom.commands.dispatch(bufferView.element, 'pane:split-down')
-
-      await conditionPromise(() => atom.workspace.getCenter().getPanes().length === 2)
-
-      await conditionPromise(() => atom.workspace.getActiveTextEditor())
-
-      const [topPane, bottomPane] = atom.workspace.getCenter().getPanes() // eslint-disable-line no-unused-vars
-      expect(atom.workspace.getActivePane()).toBe(bottomPane)
-      expect(atom.workspace.getActiveTextEditor().getPath()).toBe(atom.project.getDirectories()[0].resolve(filePath))
-    })
-  })
-
-  describe('when the query contains a colon', () => {
-    beforeEach(async () => {
-      jasmine.attachToDOM(workspaceElement)
-      expect(atom.workspace.panelForItem(projectView)).toBeNull()
-
-      await atom.workspace.open('sample.txt')
-
-      const [editor1, editor2] = atom.workspace.getTextEditors()
-      editor1.setCursorBufferPosition([8, 3])
-      expect(atom.workspace.getActiveTextEditor()).toBe(editor2)
-      expect(editor1.getCursorBufferPosition()).toEqual([8, 3])
-    })
-
-    describe('when the colon is followed by numbers', () => {
-      describe('when the numbers are not followed by another colon', () => {
+      describe('when the colon is not followed by numbers', () => {
         describe('when the filter text has a file path', () => {
-          it('opens the selected path to that line number', async () => {
+          it('opens the file and does not throw an error', async () => {
             const [editor1, editor2] = atom.workspace.getTextEditors() // eslint-disable-line no-unused-vars
 
             await bufferView.toggle()
 
             expect(atom.workspace.panelForItem(bufferView).isVisible()).toBe(true)
-            bufferView.selectListView.refs.queryEditor.setText('sample.js:4')
+            bufferView.selectListView.refs.queryEditor.setText('sample.js:a')
 
             await getOrScheduleUpdatePromise()
 
@@ -853,12 +1037,12 @@ describe('FuzzyFinder', () => {
             await conditionPromise(() => bufferView.moveToCaretPosition.callCount > 0)
 
             expect(atom.workspace.getActiveTextEditor()).toBe(editor1)
-            expect(editor1.getCursorBufferPosition()).toEqual([3, 4])
+            expect(editor1.getCursorBufferPosition()).toEqual([8, 3])
           })
         })
 
         describe("when the filter text doesn't have a file path", () => {
-          it('moves the cursor in the active editor to that line number', async () => {
+          it('shows an error and does not move the cursor', async () => {
             const [editor1, editor2] = atom.workspace.getTextEditors() // eslint-disable-line no-unused-vars
 
             await atom.workspace.open('sample.js')
@@ -868,9 +1052,11 @@ describe('FuzzyFinder', () => {
             await bufferView.toggle()
 
             expect(atom.workspace.panelForItem(bufferView).isVisible()).toBe(true)
-            bufferView.selectListView.refs.queryEditor.insertText(':4')
+            bufferView.selectListView.refs.queryEditor.setText('::')
 
             await getOrScheduleUpdatePromise()
+
+            expect(bufferView.selectListView.refs.errorMessage.innerText).toEqual('Invalid line number')
 
             expect(bufferView.element.querySelectorAll('li').length).toBe(0)
             spyOn(bufferView, 'moveToCaretPosition').andCallThrough()
@@ -879,147 +1065,156 @@ describe('FuzzyFinder', () => {
             await conditionPromise(() => bufferView.moveToCaretPosition.callCount > 0)
 
             expect(atom.workspace.getActiveTextEditor()).toBe(editor1)
-            expect(editor1.getCursorBufferPosition()).toEqual([3, 4])
-          })
-        })
-      })
-
-      describe('when the numbers are followed by another colon', () => {
-        describe('when the colon is followed by more numbers', () => {
-          describe('when the filter text has a file path', () => {
-            it('opens the selected path to that line number and column', async () => {
-              const [editor1, editor2] = atom.workspace.getTextEditors() // eslint-disable-line no-unused-vars
-
-              await bufferView.toggle()
-
-              expect(atom.workspace.panelForItem(bufferView).isVisible()).toBe(true)
-              bufferView.selectListView.refs.queryEditor.setText('sample.js:4:6')
-
-              await getOrScheduleUpdatePromise()
-
-              const {filePath} = bufferView.selectListView.getSelectedItem()
-              expect(atom.project.getDirectories()[0].resolve(filePath)).toBe(editor1.getPath())
-
-              spyOn(bufferView, 'moveToCaretPosition').andCallThrough()
-              atom.commands.dispatch(bufferView.element, 'core:confirm')
-
-              await conditionPromise(() => bufferView.moveToCaretPosition.callCount > 0)
-
-              expect(atom.workspace.getActiveTextEditor()).toBe(editor1)
-              expect(editor1.getCursorBufferPosition()).toEqual([3, 6])
-            })
+            expect(editor1.getCursorBufferPosition()).toEqual([8, 3])
           })
 
-          describe("when the filter text doesn't have a file path", () => {
-            it('moves the cursor in the active editor to that line number and column', async () => {
-              const [editor1, editor2] = atom.workspace.getTextEditors() // eslint-disable-line no-unused-vars
+          it('updates the message when the error gets resolved', async () => {
+            const [editor1, editor2] = atom.workspace.getTextEditors() // eslint-disable-line no-unused-vars
 
-              await atom.workspace.open('sample.js')
+            const emptyMessage = 'Jump to line in active editor'
+            const errorMessage = 'Invalid line number'
 
-              expect(atom.workspace.getActiveTextEditor()).toBe(editor1)
+            await atom.workspace.open('sample.js')
 
-              await bufferView.toggle()
+            expect(atom.workspace.getActiveTextEditor()).toBe(editor1)
 
-              expect(atom.workspace.panelForItem(bufferView).isVisible()).toBe(true)
-              bufferView.selectListView.refs.queryEditor.insertText(':4:6')
+            await bufferView.toggle()
 
-              await getOrScheduleUpdatePromise()
+            expect(atom.workspace.panelForItem(bufferView).isVisible()).toBe(true)
 
-              expect(bufferView.selectListView.refs.emptyMessage.innerText).toEqual(
-                'Jump to line and column in active editor'
-              )
-              expect(bufferView.element.querySelectorAll('li').length).toBe(0)
-              spyOn(bufferView, 'moveToCaretPosition').andCallThrough()
-              atom.commands.dispatch(bufferView.element, 'core:confirm')
+            bufferView.selectListView.refs.queryEditor.setText(':42')
+            await getOrScheduleUpdatePromise()
+            expect(bufferView.selectListView.refs.emptyMessage.innerText).toEqual(emptyMessage)
+            expect(bufferView.selectListView.refs.errorMessage).toBeUndefined()
 
-              await conditionPromise(() => bufferView.moveToCaretPosition.callCount > 0)
+            bufferView.selectListView.refs.queryEditor.setText(':42a')
+            await getOrScheduleUpdatePromise()
+            expect(bufferView.selectListView.refs.emptyMessage).toBeUndefined()
+            expect(bufferView.selectListView.refs.errorMessage.innerText).toEqual(errorMessage)
 
-              expect(atom.workspace.getActiveTextEditor()).toBe(editor1)
-              expect(editor1.getCursorBufferPosition()).toEqual([3, 6])
-            })
-          })
-        })
-
-        describe('when the colon is not followed by more numbers', () => {
-          describe('when the filter text has a file path', () => {
-            it('opens the file, jumps to the first character of the line and does not throw an error', async () => {
-              const [editor1, editor2] = atom.workspace.getTextEditors() // eslint-disable-line no-unused-vars
-
-              await bufferView.toggle()
-
-              expect(atom.workspace.panelForItem(bufferView).isVisible()).toBe(true)
-              bufferView.selectListView.refs.queryEditor.setText('sample.js:5:a')
-
-              await getOrScheduleUpdatePromise()
-
-              const {filePath} = bufferView.selectListView.getSelectedItem()
-              expect(atom.project.getDirectories()[0].resolve(filePath)).toBe(editor1.getPath())
-
-              spyOn(bufferView, 'moveToCaretPosition').andCallThrough()
-              atom.commands.dispatch(bufferView.element, 'core:confirm')
-
-              await conditionPromise(() => bufferView.moveToCaretPosition.callCount > 0)
-
-              expect(atom.workspace.getActiveTextEditor()).toBe(editor1)
-              expect(editor1.getCursorBufferPosition()).toEqual([4, 4])
-            })
+            bufferView.selectListView.refs.queryEditor.setText(':42')
+            await getOrScheduleUpdatePromise()
+            expect(bufferView.selectListView.refs.emptyMessage.innerText).toEqual(emptyMessage)
+            expect(bufferView.selectListView.refs.errorMessage).toBeUndefined()
           })
 
-          describe("when the filter text doesn't have a file path", () => {
-            it('jumps to the first character of the line and does not throw an error', async () => {
-              const [editor1, editor2] = atom.workspace.getTextEditors() // eslint-disable-line no-unused-vars
+          it('shows a specific error message when the column is invalid', async () => {
+            const [editor1] = atom.workspace.getTextEditors()
+            const errorMessage = 'Invalid column number'
 
-              await atom.workspace.open('sample.js')
+            await atom.workspace.open('sample.js')
 
-              expect(atom.workspace.getActiveTextEditor()).toBe(editor1)
+            expect(atom.workspace.getActiveTextEditor()).toBe(editor1)
 
-              await bufferView.toggle()
+            await bufferView.toggle()
 
-              expect(atom.workspace.panelForItem(bufferView).isVisible()).toBe(true)
-              bufferView.selectListView.refs.queryEditor.setText(':5:a')
+            expect(atom.workspace.panelForItem(bufferView).isVisible()).toBe(true)
 
-              await getOrScheduleUpdatePromise()
+            bufferView.selectListView.refs.queryEditor.setText(':42:12a')
+            await getOrScheduleUpdatePromise()
+            expect(bufferView.selectListView.refs.emptyMessage).toBeUndefined()
+            expect(bufferView.selectListView.refs.errorMessage.innerText).toEqual(errorMessage)
+          })
 
-              spyOn(bufferView, 'moveToCaretPosition').andCallThrough()
-              atom.commands.dispatch(bufferView.element, 'core:confirm')
+          it('shows a more specific message when jumping to line and column', async () => {
+            const [editor1] = atom.workspace.getTextEditors()
+            const emptyColumnMessage = 'Jump to line and column in active editor'
 
-              await conditionPromise(() => bufferView.moveToCaretPosition.callCount > 0)
+            await atom.workspace.open('sample.js')
 
-              expect(atom.workspace.getActiveTextEditor()).toBe(editor1)
-              expect(editor1.getCursorBufferPosition()).toEqual([4, 4])
-            })
+            expect(atom.workspace.getActiveTextEditor()).toBe(editor1)
+
+            await bufferView.toggle()
+
+            expect(atom.workspace.panelForItem(bufferView).isVisible()).toBe(true)
+
+            bufferView.selectListView.refs.queryEditor.setText(':42:')
+            await getOrScheduleUpdatePromise()
+            expect(bufferView.selectListView.refs.emptyMessage.innerText).toEqual(emptyColumnMessage)
+
+            bufferView.selectListView.refs.queryEditor.setText(':42:12')
+            await getOrScheduleUpdatePromise()
+            expect(bufferView.selectListView.refs.emptyMessage.innerText).toEqual(emptyColumnMessage)
           })
         })
       })
     })
 
-    describe('when the colon is not followed by numbers', () => {
-      describe('when the filter text has a file path', () => {
-        it('opens the file and does not throw an error', async () => {
-          const [editor1, editor2] = atom.workspace.getTextEditors() // eslint-disable-line no-unused-vars
-
-          await bufferView.toggle()
-
-          expect(atom.workspace.panelForItem(bufferView).isVisible()).toBe(true)
-          bufferView.selectListView.refs.queryEditor.setText('sample.js:a')
-
-          await getOrScheduleUpdatePromise()
-
-          const {filePath} = bufferView.selectListView.getSelectedItem()
-          expect(atom.project.getDirectories()[0].resolve(filePath)).toBe(editor1.getPath())
-
-          spyOn(bufferView, 'moveToCaretPosition').andCallThrough()
-          atom.commands.dispatch(bufferView.element, 'core:confirm')
-
-          await conditionPromise(() => bufferView.moveToCaretPosition.callCount > 0)
-
-          expect(atom.workspace.getActiveTextEditor()).toBe(editor1)
-          expect(editor1.getCursorBufferPosition()).toEqual([8, 3])
-        })
+    describe('match highlighting', () => {
+      beforeEach(async () => {
+        jasmine.attachToDOM(workspaceElement)
+        await bufferView.toggle()
       })
 
-      describe("when the filter text doesn't have a file path", () => {
-        it('shows an error and does not move the cursor', async () => {
+      it('highlights an exact match', async () => {
+        bufferView.selectListView.refs.queryEditor.setText('sample.js')
+
+        await getOrScheduleUpdatePromise()
+
+        const resultView = bufferView.element.querySelector('li')
+        const primaryMatches = resultView.querySelectorAll('.primary-line .character-match')
+        const secondaryMatches = resultView.querySelectorAll('.secondary-line .character-match')
+        expect(primaryMatches.length).toBe(1)
+        expect(primaryMatches[primaryMatches.length - 1].textContent).toBe('sample.js')
+        // Use `toBeGreaterThan` because dir may have some characters in it
+        expect(secondaryMatches.length).toBeGreaterThan(0)
+        expect(secondaryMatches[secondaryMatches.length - 1].textContent).toBe('sample.js')
+      })
+
+      it('highlights a partial match', async () => {
+        bufferView.selectListView.refs.queryEditor.setText('sample')
+
+        await getOrScheduleUpdatePromise()
+
+        const resultView = bufferView.element.querySelector('li')
+        const primaryMatches = resultView.querySelectorAll('.primary-line .character-match')
+        const secondaryMatches = resultView.querySelectorAll('.secondary-line .character-match')
+        expect(primaryMatches.length).toBe(1)
+        expect(primaryMatches[primaryMatches.length - 1].textContent).toBe('sample')
+        // Use `toBeGreaterThan` because dir may have some characters in it
+        expect(secondaryMatches.length).toBeGreaterThan(0)
+        expect(secondaryMatches[secondaryMatches.length - 1].textContent).toBe('sample')
+      })
+
+      it('highlights multiple matches in the file name', async () => {
+        bufferView.selectListView.refs.queryEditor.setText('samplejs')
+
+        await getOrScheduleUpdatePromise()
+
+        const resultView = bufferView.element.querySelector('li')
+        const primaryMatches = resultView.querySelectorAll('.primary-line .character-match')
+        const secondaryMatches = resultView.querySelectorAll('.secondary-line .character-match')
+        expect(primaryMatches.length).toBe(2)
+        expect(primaryMatches[0].textContent).toBe('sample')
+        expect(primaryMatches[primaryMatches.length - 1].textContent).toBe('js')
+        // Use `toBeGreaterThan` because dir may have some characters in it
+        expect(secondaryMatches.length).toBeGreaterThan(1)
+        expect(secondaryMatches[secondaryMatches.length - 1].textContent).toBe('js')
+      })
+
+      it('highlights matches in the directory and file name', async () => {
+        spyOn(bufferView, 'projectRelativePathsForFilePaths').andCallFake((paths) => paths)
+        bufferView.selectListView.refs.queryEditor.setText('root-dirsample')
+
+        await bufferView.setItems([
+          {
+            filePath: '/test/root-dir1/sample.js',
+            label: 'root-dir1/sample.js'
+          }
+        ])
+
+        const resultView = bufferView.element.querySelector('li')
+        const primaryMatches = resultView.querySelectorAll('.primary-line .character-match')
+        const secondaryMatches = resultView.querySelectorAll('.secondary-line .character-match')
+        expect(primaryMatches.length).toBe(1)
+        expect(primaryMatches[primaryMatches.length - 1].textContent).toBe('sample')
+        expect(secondaryMatches.length).toBe(2)
+        expect(secondaryMatches[0].textContent).toBe('root-dir')
+        expect(secondaryMatches[secondaryMatches.length - 1].textContent).toBe('sample')
+      })
+
+      describe('when splitting panes', () => {
+        it('opens the selected path to that line number in a new pane', async () => {
           const [editor1, editor2] = atom.workspace.getTextEditors() // eslint-disable-line no-unused-vars
 
           await atom.workspace.open('sample.js')
@@ -1029,305 +1224,94 @@ describe('FuzzyFinder', () => {
           await bufferView.toggle()
 
           expect(atom.workspace.panelForItem(bufferView).isVisible()).toBe(true)
-          bufferView.selectListView.refs.queryEditor.setText('::')
+          bufferView.selectListView.refs.queryEditor.insertText(':4')
 
           await getOrScheduleUpdatePromise()
-
-          expect(bufferView.selectListView.refs.errorMessage.innerText).toEqual('Invalid line number')
 
           expect(bufferView.element.querySelectorAll('li').length).toBe(0)
           spyOn(bufferView, 'moveToCaretPosition').andCallThrough()
-          atom.commands.dispatch(bufferView.element, 'core:confirm')
+          atom.commands.dispatch(bufferView.element, 'pane:split-left')
 
           await conditionPromise(() => bufferView.moveToCaretPosition.callCount > 0)
 
-          expect(atom.workspace.getActiveTextEditor()).toBe(editor1)
-          expect(editor1.getCursorBufferPosition()).toEqual([8, 3])
-        })
-
-        it('updates the message when the error gets resolved', async () => {
-          const [editor1, editor2] = atom.workspace.getTextEditors() // eslint-disable-line no-unused-vars
-
-          const emptyMessage = 'Jump to line in active editor'
-          const errorMessage = 'Invalid line number'
-
-          await atom.workspace.open('sample.js')
-
-          expect(atom.workspace.getActiveTextEditor()).toBe(editor1)
-
-          await bufferView.toggle()
-
-          expect(atom.workspace.panelForItem(bufferView).isVisible()).toBe(true)
-
-          bufferView.selectListView.refs.queryEditor.setText(':42')
-          await getOrScheduleUpdatePromise()
-          expect(bufferView.selectListView.refs.emptyMessage.innerText).toEqual(emptyMessage)
-          expect(bufferView.selectListView.refs.errorMessage).toBeUndefined()
-
-          bufferView.selectListView.refs.queryEditor.setText(':42a')
-          await getOrScheduleUpdatePromise()
-          expect(bufferView.selectListView.refs.emptyMessage).toBeUndefined()
-          expect(bufferView.selectListView.refs.errorMessage.innerText).toEqual(errorMessage)
-
-          bufferView.selectListView.refs.queryEditor.setText(':42')
-          await getOrScheduleUpdatePromise()
-          expect(bufferView.selectListView.refs.emptyMessage.innerText).toEqual(emptyMessage)
-          expect(bufferView.selectListView.refs.errorMessage).toBeUndefined()
-        })
-
-        it('shows a specific error message when the column is invalid', async () => {
-          const [editor1] = atom.workspace.getTextEditors()
-          const errorMessage = 'Invalid column number'
-
-          await atom.workspace.open('sample.js')
-
-          expect(atom.workspace.getActiveTextEditor()).toBe(editor1)
-
-          await bufferView.toggle()
-
-          expect(atom.workspace.panelForItem(bufferView).isVisible()).toBe(true)
-
-          bufferView.selectListView.refs.queryEditor.setText(':42:12a')
-          await getOrScheduleUpdatePromise()
-          expect(bufferView.selectListView.refs.emptyMessage).toBeUndefined()
-          expect(bufferView.selectListView.refs.errorMessage.innerText).toEqual(errorMessage)
-        })
-
-        it('shows a more specific message when jumping to line and column', async () => {
-          const [editor1] = atom.workspace.getTextEditors()
-          const emptyColumnMessage = 'Jump to line and column in active editor'
-
-          await atom.workspace.open('sample.js')
-
-          expect(atom.workspace.getActiveTextEditor()).toBe(editor1)
-
-          await bufferView.toggle()
-
-          expect(atom.workspace.panelForItem(bufferView).isVisible()).toBe(true)
-
-          bufferView.selectListView.refs.queryEditor.setText(':42:')
-          await getOrScheduleUpdatePromise()
-          expect(bufferView.selectListView.refs.emptyMessage.innerText).toEqual(emptyColumnMessage)
-
-          bufferView.selectListView.refs.queryEditor.setText(':42:12')
-          await getOrScheduleUpdatePromise()
-          expect(bufferView.selectListView.refs.emptyMessage.innerText).toEqual(emptyColumnMessage)
+          expect(atom.workspace.getActiveTextEditor()).not.toBe(editor1)
+          expect(atom.workspace.getActiveTextEditor().getPath()).toBe(editor1.getPath())
+          expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual([3, 4])
         })
       })
     })
-  })
 
-  describe('match highlighting', () => {
-    beforeEach(async () => {
-      jasmine.attachToDOM(workspaceElement)
-      await bufferView.toggle()
-    })
+    describe('preserve last search', () => {
+      it('does not preserve last search by default', async () => {
+        await projectView.toggle()
 
-    it('highlights an exact match', async () => {
-      bufferView.selectListView.refs.queryEditor.setText('sample.js')
+        expect(atom.workspace.panelForItem(projectView).isVisible()).toBe(true)
+        bufferView.selectListView.refs.queryEditor.insertText('this should not show up next time we open finder')
 
-      await getOrScheduleUpdatePromise()
+        await projectView.toggle()
 
-      const resultView = bufferView.element.querySelector('li')
-      const primaryMatches = resultView.querySelectorAll('.primary-line .character-match')
-      const secondaryMatches = resultView.querySelectorAll('.secondary-line .character-match')
-      expect(primaryMatches.length).toBe(1)
-      expect(primaryMatches[primaryMatches.length - 1].textContent).toBe('sample.js')
-      // Use `toBeGreaterThan` because dir may have some characters in it
-      expect(secondaryMatches.length).toBeGreaterThan(0)
-      expect(secondaryMatches[secondaryMatches.length - 1].textContent).toBe('sample.js')
-    })
+        expect(atom.workspace.panelForItem(projectView).isVisible()).toBe(false)
 
-    it('highlights a partial match', async () => {
-      bufferView.selectListView.refs.queryEditor.setText('sample')
+        await projectView.toggle()
 
-      await getOrScheduleUpdatePromise()
-
-      const resultView = bufferView.element.querySelector('li')
-      const primaryMatches = resultView.querySelectorAll('.primary-line .character-match')
-      const secondaryMatches = resultView.querySelectorAll('.secondary-line .character-match')
-      expect(primaryMatches.length).toBe(1)
-      expect(primaryMatches[primaryMatches.length - 1].textContent).toBe('sample')
-      // Use `toBeGreaterThan` because dir may have some characters in it
-      expect(secondaryMatches.length).toBeGreaterThan(0)
-      expect(secondaryMatches[secondaryMatches.length - 1].textContent).toBe('sample')
-    })
-
-    it('highlights multiple matches in the file name', async () => {
-      bufferView.selectListView.refs.queryEditor.setText('samplejs')
-
-      await getOrScheduleUpdatePromise()
-
-      const resultView = bufferView.element.querySelector('li')
-      const primaryMatches = resultView.querySelectorAll('.primary-line .character-match')
-      const secondaryMatches = resultView.querySelectorAll('.secondary-line .character-match')
-      expect(primaryMatches.length).toBe(2)
-      expect(primaryMatches[0].textContent).toBe('sample')
-      expect(primaryMatches[primaryMatches.length - 1].textContent).toBe('js')
-      // Use `toBeGreaterThan` because dir may have some characters in it
-      expect(secondaryMatches.length).toBeGreaterThan(1)
-      expect(secondaryMatches[secondaryMatches.length - 1].textContent).toBe('js')
-    })
-
-    it('highlights matches in the directory and file name', async () => {
-      spyOn(bufferView, 'projectRelativePathsForFilePaths').andCallFake((paths) => paths)
-      bufferView.selectListView.refs.queryEditor.setText('root-dirsample')
-
-      await bufferView.setItems([
-        {
-          filePath: '/test/root-dir1/sample.js',
-          label: 'root-dir1/sample.js'
-        }
-      ])
-
-      const resultView = bufferView.element.querySelector('li')
-      const primaryMatches = resultView.querySelectorAll('.primary-line .character-match')
-      const secondaryMatches = resultView.querySelectorAll('.secondary-line .character-match')
-      expect(primaryMatches.length).toBe(1)
-      expect(primaryMatches[primaryMatches.length - 1].textContent).toBe('sample')
-      expect(secondaryMatches.length).toBe(2)
-      expect(secondaryMatches[0].textContent).toBe('root-dir')
-      expect(secondaryMatches[secondaryMatches.length - 1].textContent).toBe('sample')
-    })
-
-    describe('when splitting panes', () => {
-      it('opens the selected path to that line number in a new pane', async () => {
-        const [editor1, editor2] = atom.workspace.getTextEditors() // eslint-disable-line no-unused-vars
-
-        await atom.workspace.open('sample.js')
-
-        expect(atom.workspace.getActiveTextEditor()).toBe(editor1)
-
-        await bufferView.toggle()
-
-        expect(atom.workspace.panelForItem(bufferView).isVisible()).toBe(true)
-        bufferView.selectListView.refs.queryEditor.insertText(':4')
-
-        await getOrScheduleUpdatePromise()
-
-        expect(bufferView.element.querySelectorAll('li').length).toBe(0)
-        spyOn(bufferView, 'moveToCaretPosition').andCallThrough()
-        atom.commands.dispatch(bufferView.element, 'pane:split-left')
-
-        await conditionPromise(() => bufferView.moveToCaretPosition.callCount > 0)
-
-        expect(atom.workspace.getActiveTextEditor()).not.toBe(editor1)
-        expect(atom.workspace.getActiveTextEditor().getPath()).toBe(editor1.getPath())
-        expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual([3, 4])
-      })
-    })
-  })
-
-  describe('preserve last search', () => {
-    it('does not preserve last search by default', async () => {
-      await projectView.toggle()
-
-      expect(atom.workspace.panelForItem(projectView).isVisible()).toBe(true)
-      bufferView.selectListView.refs.queryEditor.insertText('this should not show up next time we open finder')
-
-      await projectView.toggle()
-
-      expect(atom.workspace.panelForItem(projectView).isVisible()).toBe(false)
-
-      await projectView.toggle()
-
-      expect(atom.workspace.panelForItem(projectView).isVisible()).toBe(true)
-      expect(projectView.selectListView.getQuery()).toBe('')
-    })
-
-    it('preserves last search when the config is set', async () => {
-      atom.config.set('fuzzy-finder.preserveLastSearch', true)
-
-      await projectView.toggle()
-
-      expect(atom.workspace.panelForItem(projectView).isVisible()).toBe(true)
-      projectView.selectListView.refs.queryEditor.insertText('this should show up next time we open finder')
-
-      await projectView.toggle()
-
-      expect(atom.workspace.panelForItem(projectView).isVisible()).toBe(false)
-
-      await projectView.toggle()
-
-      expect(atom.workspace.panelForItem(projectView).isVisible()).toBe(true)
-      expect(projectView.selectListView.getQuery()).toBe('this should show up next time we open finder')
-      expect(projectView.selectListView.refs.queryEditor.getSelectedText()).toBe('this should show up next time we open finder')
-    })
-  })
-
-  describe('prefill query from selection', () => {
-    it('should not be enabled by default', async () => {
-      await atom.workspace.open()
-
-      atom.workspace.getActiveTextEditor().setText('sample.txt')
-      atom.workspace.getActiveTextEditor().setSelectedBufferRange([[0, 0], [0, 10]])
-      expect(atom.workspace.getActiveTextEditor().getSelectedText()).toBe('sample.txt')
-
-      await projectView.toggle()
-
-      expect(atom.workspace.panelForItem(projectView).isVisible()).toBe(true)
-      expect(projectView.selectListView.getQuery()).toBe('')
-      expect(projectView.selectListView.refs.queryEditor.getSelectedText()).toBe('')
-    })
-
-    it('takes selection from active editor and prefills query with it', async () => {
-      atom.config.set('fuzzy-finder.prefillFromSelection', true)
-
-      await atom.workspace.open()
-
-      atom.workspace.getActiveTextEditor().setText('sample.txt')
-      atom.workspace.getActiveTextEditor().setSelectedBufferRange([[0, 0], [0, 10]])
-      expect(atom.workspace.getActiveTextEditor().getSelectedText()).toBe('sample.txt')
-
-      await projectView.toggle()
-
-      expect(atom.workspace.panelForItem(projectView).isVisible()).toBe(true)
-      expect(projectView.selectListView.getQuery()).toBe('sample.txt')
-      expect(projectView.selectListView.refs.queryEditor.getSelectedText()).toBe('sample.txt')
-    })
-  })
-
-  describe('default file icons', () => {
-    it('shows a text icon for text-based formats', async () => {
-      await atom.workspace.open('sample.js')
-
-      await bufferView.toggle()
-
-      expect(atom.workspace.panelForItem(bufferView).isVisible()).toBe(true)
-      bufferView.selectListView.refs.queryEditor.insertText('js')
-
-      await getOrScheduleUpdatePromise()
-
-      const firstResult = bufferView.element.querySelector('li .primary-line')
-      expect(DefaultFileIcons.iconClassForPath(firstResult.dataset.path)).toBe('icon-file-text')
-    })
-
-    it('shows an image icon for graphic formats', async () => {
-      await atom.workspace.open('sample.gif')
-
-      await bufferView.toggle()
-
-      expect(atom.workspace.panelForItem(bufferView).isVisible()).toBe(true)
-      bufferView.selectListView.refs.queryEditor.insertText('gif')
-
-      await getOrScheduleUpdatePromise()
-
-      const firstResult = bufferView.element.querySelector('li .primary-line')
-      expect(DefaultFileIcons.iconClassForPath(firstResult.dataset.path)).toBe('icon-file-media')
-    })
-  })
-
-  describe('icon services', () => {
-    describe('atom.file-icons', () => {
-      it('has a default handler', () => {
-        expect(getIconServices().fileIcons).toBe(DefaultFileIcons)
+        expect(atom.workspace.panelForItem(projectView).isVisible()).toBe(true)
+        expect(projectView.selectListView.getQuery()).toBe('')
       })
 
-      it('allows services to replace the default handler', async () => {
-        const provider = {iconClassForPath: () => 'foo bar'}
-        const disposable = atom.packages.serviceHub.provide('atom.file-icons', '1.0.0', provider)
-        expect(getIconServices().fileIcons).toBe(provider)
+      it('preserves last search when the config is set', async () => {
+        atom.config.set('fuzzy-finder.preserveLastSearch', true)
 
+        await projectView.toggle()
+
+        expect(atom.workspace.panelForItem(projectView).isVisible()).toBe(true)
+        projectView.selectListView.refs.queryEditor.insertText('this should show up next time we open finder')
+
+        await projectView.toggle()
+
+        expect(atom.workspace.panelForItem(projectView).isVisible()).toBe(false)
+
+        await projectView.toggle()
+
+        expect(atom.workspace.panelForItem(projectView).isVisible()).toBe(true)
+        expect(projectView.selectListView.getQuery()).toBe('this should show up next time we open finder')
+        expect(projectView.selectListView.refs.queryEditor.getSelectedText()).toBe('this should show up next time we open finder')
+      })
+    })
+
+    describe('prefill query from selection', () => {
+      it('should not be enabled by default', async () => {
+        await atom.workspace.open()
+
+        atom.workspace.getActiveTextEditor().setText('sample.txt')
+        atom.workspace.getActiveTextEditor().setSelectedBufferRange([[0, 0], [0, 10]])
+        expect(atom.workspace.getActiveTextEditor().getSelectedText()).toBe('sample.txt')
+
+        await projectView.toggle()
+
+        expect(atom.workspace.panelForItem(projectView).isVisible()).toBe(true)
+        expect(projectView.selectListView.getQuery()).toBe('')
+        expect(projectView.selectListView.refs.queryEditor.getSelectedText()).toBe('')
+      })
+
+      it('takes selection from active editor and prefills query with it', async () => {
+        atom.config.set('fuzzy-finder.prefillFromSelection', true)
+
+        await atom.workspace.open()
+
+        atom.workspace.getActiveTextEditor().setText('sample.txt')
+        atom.workspace.getActiveTextEditor().setSelectedBufferRange([[0, 0], [0, 10]])
+        expect(atom.workspace.getActiveTextEditor().getSelectedText()).toBe('sample.txt')
+
+        await projectView.toggle()
+
+        expect(atom.workspace.panelForItem(projectView).isVisible()).toBe(true)
+        expect(projectView.selectListView.getQuery()).toBe('sample.txt')
+        expect(projectView.selectListView.refs.queryEditor.getSelectedText()).toBe('sample.txt')
+      })
+    })
+
+    describe('default file icons', () => {
+      it('shows a text icon for text-based formats', async () => {
         await atom.workspace.open('sample.js')
 
         await bufferView.toggle()
@@ -1338,212 +1322,252 @@ describe('FuzzyFinder', () => {
         await getOrScheduleUpdatePromise()
 
         const firstResult = bufferView.element.querySelector('li .primary-line')
-        expect(firstResult).toBeDefined()
-        expect(firstResult.className).toBe('primary-line file icon foo bar')
-        disposable.dispose()
-        expect(getIconServices().fileIcons).toBe(DefaultFileIcons)
+        expect(DefaultFileIcons.iconClassForPath(firstResult.dataset.path)).toBe('icon-file-text')
+      })
+
+      it('shows an image icon for graphic formats', async () => {
+        await atom.workspace.open('sample.gif')
+
+        await bufferView.toggle()
+
+        expect(atom.workspace.panelForItem(bufferView).isVisible()).toBe(true)
+        bufferView.selectListView.refs.queryEditor.insertText('gif')
+
+        await getOrScheduleUpdatePromise()
+
+        const firstResult = bufferView.element.querySelector('li .primary-line')
+        expect(DefaultFileIcons.iconClassForPath(firstResult.dataset.path)).toBe('icon-file-media')
       })
     })
 
-    describe('file-icons.element-icons', () => {
-      it('has no default handler', () => {
-        expect(getIconServices().elementIcons).toBe(null)
+    describe('icon services', () => {
+      describe('atom.file-icons', () => {
+        it('has a default handler', () => {
+          expect(getIconServices().fileIcons).toBe(DefaultFileIcons)
+        })
+
+        it('allows services to replace the default handler', async () => {
+          const provider = {iconClassForPath: () => 'foo bar'}
+          const disposable = atom.packages.serviceHub.provide('atom.file-icons', '1.0.0', provider)
+          expect(getIconServices().fileIcons).toBe(provider)
+
+          await atom.workspace.open('sample.js')
+
+          await bufferView.toggle()
+
+          expect(atom.workspace.panelForItem(bufferView).isVisible()).toBe(true)
+          bufferView.selectListView.refs.queryEditor.insertText('js')
+
+          await getOrScheduleUpdatePromise()
+
+          const firstResult = bufferView.element.querySelector('li .primary-line')
+          expect(firstResult).toBeDefined()
+          expect(firstResult.className).toBe('primary-line file icon foo bar')
+          disposable.dispose()
+          expect(getIconServices().fileIcons).toBe(DefaultFileIcons)
+        })
       })
 
-      it('uses the element-icon service if available', async () => {
-        const provider = element => {
-          element.classList.add('foo', 'bar')
-          return new Disposable(() => {
-            element.classList.remove('foo', 'bar')
+      describe('file-icons.element-icons', () => {
+        it('has no default handler', () => {
+          expect(getIconServices().elementIcons).toBe(null)
+        })
+
+        it('uses the element-icon service if available', async () => {
+          const provider = element => {
+            element.classList.add('foo', 'bar')
+            return new Disposable(() => {
+              element.classList.remove('foo', 'bar')
+            })
+          }
+          const disposable = atom.packages.serviceHub.provide('file-icons.element-icons', '1.0.0', provider)
+          expect(getIconServices().elementIcons).toBe(provider)
+
+          await atom.workspace.open('sample.js')
+
+          await bufferView.toggle()
+
+          expect(atom.workspace.panelForItem(bufferView).isVisible()).toBe(true)
+          bufferView.selectListView.refs.queryEditor.insertText('js')
+
+          await getOrScheduleUpdatePromise()
+
+          const firstResult = bufferView.element.querySelector('li .primary-line')
+          expect(firstResult).toBeDefined()
+          expect(firstResult.className).toBe('primary-line file icon foo bar')
+          disposable.dispose()
+          expect(getIconServices().elementIcons).toBe(null)
+          expect(firstResult.classList).not.toBe('primary-line file icon foo bar')
+        })
+      })
+
+      describe('when both services are provided', () => {
+        it('gives priority to the element-icon service', async () => {
+          const basicProvider = {iconClassForPath: () => 'foo'}
+          const elementProvider = element => {
+            element.classList.add('bar')
+            return new Disposable(() => {
+              element.classList.remove('bar')
+            })
+          }
+          spyOn(basicProvider, 'iconClassForPath').andCallThrough()
+          atom.packages.serviceHub.provide('atom.file-icons', '1.0.0', basicProvider)
+          atom.packages.serviceHub.provide('file-icons.element-icons', '1.0.0', elementProvider)
+          expect(getIconServices().fileIcons).toBe(basicProvider)
+          expect(getIconServices().elementIcons).toBe(elementProvider)
+
+          await atom.workspace.open('sample.js')
+
+          await bufferView.toggle()
+
+          expect(atom.workspace.panelForItem(bufferView).isVisible()).toBe(true)
+          bufferView.selectListView.refs.queryEditor.insertText('js')
+
+          await getOrScheduleUpdatePromise()
+
+          const firstResult = bufferView.element.querySelector('li .primary-line')
+          expect(firstResult).toBeDefined()
+          expect(firstResult.className).toBe('primary-line file icon bar')
+          expect(basicProvider.iconClassForPath).not.toHaveBeenCalled()
+        })
+      })
+    })
+
+    describe('Git integration', () => {
+      let projectPath, gitRepository, gitDirectory
+
+      beforeEach(() => {
+        projectPath = atom.project.getDirectories()[0].resolve('git/working-dir')
+        fs.moveSync(path.join(projectPath, 'git.git'), path.join(projectPath, '.git'))
+        atom.project.setPaths([rootDir2, projectPath])
+
+        gitDirectory = atom.project.getDirectories()[1]
+        gitRepository = atom.project.getRepositories()[1]
+
+        waitsFor(done => gitRepository.onDidChangeStatuses(done))
+      })
+
+      describe('git-status-finder behavior', () => {
+        let originalPath, newPath
+
+        beforeEach(async () => {
+          jasmine.attachToDOM(workspaceElement)
+
+          await atom.workspace.open(path.join(projectPath, 'a.txt'))
+
+          const editor = atom.workspace.getActiveTextEditor()
+          originalPath = editor.getPath()
+          fs.writeFileSync(originalPath, 'making a change for the better')
+          gitRepository.getPathStatus(originalPath)
+
+          newPath = atom.project.getDirectories()[1].resolve('newsample.js')
+          fs.writeFileSync(newPath, '')
+          gitRepository.getPathStatus(newPath)
+        })
+
+        it('displays all new and modified paths', async () => {
+          expect(atom.workspace.panelForItem(gitStatusView)).toBeNull()
+          await gitStatusView.toggle()
+
+          expect(atom.workspace.panelForItem(gitStatusView).isVisible()).toBe(true)
+          expect(gitStatusView.element.querySelectorAll('.file').length).toBe(4)
+          expect(gitStatusView.element.querySelectorAll('.status.status-modified').length).toBe(1)
+          expect(gitStatusView.element.querySelectorAll('.status.status-added').length).toBe(3)
+        })
+      })
+
+      describe('status decorations', () => {
+        let originalPath, editor, newPath
+
+        beforeEach(async () => {
+          jasmine.attachToDOM(workspaceElement)
+
+          await atom.workspace.open(path.join(projectPath, 'a.txt'))
+
+          editor = atom.workspace.getActiveTextEditor()
+          originalPath = editor.getPath()
+          newPath = gitDirectory.resolve('newsample.js')
+          fs.writeFileSync(newPath, '')
+          fs.writeFileSync(originalPath, 'a change')
+        })
+
+        describe('when a modified file is shown in the list', () =>
+          it('displays the modified icon', async () => {
+            gitRepository.getPathStatus(editor.getPath())
+
+            await bufferView.toggle()
+
+            expect(bufferView.element.querySelectorAll('.status.status-modified').length).toBe(1)
+            expect(bufferView.element.querySelector('.status.status-modified').closest('li').querySelector('.file').textContent).toBe('a.txt')
           })
-        }
-        const disposable = atom.packages.serviceHub.provide('file-icons.element-icons', '1.0.0', provider)
-        expect(getIconServices().elementIcons).toBe(provider)
+        )
 
-        await atom.workspace.open('sample.js')
+        describe('when a new file is shown in the list', () =>
+          it('displays the new icon', async () => {
+            await atom.workspace.open(path.join(projectPath, 'newsample.js'))
 
-        await bufferView.toggle()
+            gitRepository.getPathStatus(editor.getPath())
 
-        expect(atom.workspace.panelForItem(bufferView).isVisible()).toBe(true)
-        bufferView.selectListView.refs.queryEditor.insertText('js')
+            await bufferView.toggle()
 
-        await getOrScheduleUpdatePromise()
-
-        const firstResult = bufferView.element.querySelector('li .primary-line')
-        expect(firstResult).toBeDefined()
-        expect(firstResult.className).toBe('primary-line file icon foo bar')
-        disposable.dispose()
-        expect(getIconServices().elementIcons).toBe(null)
-        expect(firstResult.classList).not.toBe('primary-line file icon foo bar')
-      })
-    })
-
-    describe('when both services are provided', () => {
-      it('gives priority to the element-icon service', async () => {
-        const basicProvider = {iconClassForPath: () => 'foo'}
-        const elementProvider = element => {
-          element.classList.add('bar')
-          return new Disposable(() => {
-            element.classList.remove('bar')
+            expect(bufferView.element.querySelectorAll('.status.status-added').length).toBe(1)
+            expect(bufferView.element.querySelector('.status.status-added').closest('li').querySelector('.file').textContent).toBe('newsample.js')
           })
-        }
-        spyOn(basicProvider, 'iconClassForPath').andCallThrough()
-        atom.packages.serviceHub.provide('atom.file-icons', '1.0.0', basicProvider)
-        atom.packages.serviceHub.provide('file-icons.element-icons', '1.0.0', elementProvider)
-        expect(getIconServices().fileIcons).toBe(basicProvider)
-        expect(getIconServices().elementIcons).toBe(elementProvider)
-
-        await atom.workspace.open('sample.js')
-
-        await bufferView.toggle()
-
-        expect(atom.workspace.panelForItem(bufferView).isVisible()).toBe(true)
-        bufferView.selectListView.refs.queryEditor.insertText('js')
-
-        await getOrScheduleUpdatePromise()
-
-        const firstResult = bufferView.element.querySelector('li .primary-line')
-        expect(firstResult).toBeDefined()
-        expect(firstResult.className).toBe('primary-line file icon bar')
-        expect(basicProvider.iconClassForPath).not.toHaveBeenCalled()
-      })
-    })
-  })
-
-  describe('Git integration', () => {
-    let projectPath, gitRepository, gitDirectory
-
-    beforeEach(() => {
-      projectPath = atom.project.getDirectories()[0].resolve('git/working-dir')
-      fs.moveSync(path.join(projectPath, 'git.git'), path.join(projectPath, '.git'))
-      atom.project.setPaths([rootDir2, projectPath])
-
-      gitDirectory = atom.project.getDirectories()[1]
-      gitRepository = atom.project.getRepositories()[1]
-
-      waitsFor(done => gitRepository.onDidChangeStatuses(done))
-    })
-
-    describe('git-status-finder behavior', () => {
-      let originalPath, newPath
-
-      beforeEach(async () => {
-        jasmine.attachToDOM(workspaceElement)
-
-        await atom.workspace.open(path.join(projectPath, 'a.txt'))
-
-        const editor = atom.workspace.getActiveTextEditor()
-        originalPath = editor.getPath()
-        fs.writeFileSync(originalPath, 'making a change for the better')
-        gitRepository.getPathStatus(originalPath)
-
-        newPath = atom.project.getDirectories()[1].resolve('newsample.js')
-        fs.writeFileSync(newPath, '')
-        gitRepository.getPathStatus(newPath)
+        )
       })
 
-      it('displays all new and modified paths', async () => {
-        expect(atom.workspace.panelForItem(gitStatusView)).toBeNull()
-        await gitStatusView.toggle()
+      describe('when core.excludeVcsIgnoredPaths is set to true', () => {
+        beforeEach(() => atom.config.set('core.excludeVcsIgnoredPaths', true))
 
-        expect(atom.workspace.panelForItem(gitStatusView).isVisible()).toBe(true)
-        expect(gitStatusView.element.querySelectorAll('.file').length).toBe(4)
-        expect(gitStatusView.element.querySelectorAll('.status.status-modified').length).toBe(1)
-        expect(gitStatusView.element.querySelectorAll('.status.status-added').length).toBe(3)
-      })
-    })
+        describe("when the project's path is the repository's working directory", () => {
+          beforeEach(() => {
+            const ignoreFile = path.join(projectPath, '.gitignore')
+            fs.writeFileSync(ignoreFile, 'ignored.txt')
 
-    describe('status decorations', () => {
-      let originalPath, editor, newPath
+            const ignoredFile = path.join(projectPath, 'ignored.txt')
+            fs.writeFileSync(ignoredFile, 'ignored text')
+          })
 
-      beforeEach(async () => {
-        jasmine.attachToDOM(workspaceElement)
+          it('excludes paths that are git ignored', async () => {
+            await projectView.toggle()
 
-        await atom.workspace.open(path.join(projectPath, 'a.txt'))
+            await waitForPathsToDisplay(projectView)
 
-        editor = atom.workspace.getActiveTextEditor()
-        originalPath = editor.getPath()
-        newPath = gitDirectory.resolve('newsample.js')
-        fs.writeFileSync(newPath, '')
-        fs.writeFileSync(originalPath, 'a change')
-      })
-
-      describe('when a modified file is shown in the list', () =>
-        it('displays the modified icon', async () => {
-          gitRepository.getPathStatus(editor.getPath())
-
-          await bufferView.toggle()
-
-          expect(bufferView.element.querySelectorAll('.status.status-modified').length).toBe(1)
-          expect(bufferView.element.querySelector('.status.status-modified').closest('li').querySelector('.file').textContent).toBe('a.txt')
-        })
-      )
-
-      describe('when a new file is shown in the list', () =>
-        it('displays the new icon', async () => {
-          await atom.workspace.open(path.join(projectPath, 'newsample.js'))
-
-          gitRepository.getPathStatus(editor.getPath())
-
-          await bufferView.toggle()
-
-          expect(bufferView.element.querySelectorAll('.status.status-added').length).toBe(1)
-          expect(bufferView.element.querySelector('.status.status-added').closest('li').querySelector('.file').textContent).toBe('newsample.js')
-        })
-      )
-    })
-
-    describe('when core.excludeVcsIgnoredPaths is set to true', () => {
-      beforeEach(() => atom.config.set('core.excludeVcsIgnoredPaths', true))
-
-      describe("when the project's path is the repository's working directory", () => {
-        beforeEach(() => {
-          const ignoreFile = path.join(projectPath, '.gitignore')
-          fs.writeFileSync(ignoreFile, 'ignored.txt')
-
-          const ignoredFile = path.join(projectPath, 'ignored.txt')
-          fs.writeFileSync(ignoredFile, 'ignored text')
+            expect(Array.from(projectView.element.querySelectorAll('li')).find(a => a.textContent.includes('ignored.txt'))).not.toBeDefined()
+          })
         })
 
-        it('excludes paths that are git ignored', async () => {
-          await projectView.toggle()
+        describe("when the project's path is a subfolder of the repository's working directory", () => {
+          beforeEach(() => {
+            atom.project.setPaths([gitDirectory.resolve('dir')])
+            const ignoreFile = path.join(projectPath, '.gitignore')
+            fs.writeFileSync(ignoreFile, 'b.txt')
+          })
 
-          await waitForPathsToDisplay(projectView)
+          it('does not exclude paths that are git ignored', async () => {
+            await projectView.toggle()
 
-          expect(Array.from(projectView.element.querySelectorAll('li')).find(a => a.textContent.includes('ignored.txt'))).not.toBeDefined()
-        })
-      })
+            await waitForPathsToDisplay(projectView)
 
-      describe("when the project's path is a subfolder of the repository's working directory", () => {
-        beforeEach(() => {
-          atom.project.setPaths([gitDirectory.resolve('dir')])
-          const ignoreFile = path.join(projectPath, '.gitignore')
-          fs.writeFileSync(ignoreFile, 'b.txt')
-        })
-
-        it('does not exclude paths that are git ignored', async () => {
-          await projectView.toggle()
-
-          await waitForPathsToDisplay(projectView)
-
-          expect(Array.from(projectView.element.querySelectorAll('li')).find(a => a.textContent.includes('b.txt'))).toBeDefined()
-        })
-      })
-
-      describe('when the .gitignore matches parts of the path to the root folder', () => {
-        beforeEach(() => {
-          const ignoreFile = path.join(projectPath, '.gitignore')
-          fs.writeFileSync(ignoreFile, path.basename(projectPath))
+            expect(Array.from(projectView.element.querySelectorAll('li')).find(a => a.textContent.includes('b.txt'))).toBeDefined()
+          })
         })
 
-        it('only applies the .gitignore patterns to relative paths within the root folder', async () => {
-          await projectView.toggle()
+        describe('when the .gitignore matches parts of the path to the root folder', () => {
+          beforeEach(() => {
+            const ignoreFile = path.join(projectPath, '.gitignore')
+            fs.writeFileSync(ignoreFile, path.basename(projectPath))
+          })
 
-          await waitForPathsToDisplay(projectView)
+          it('only applies the .gitignore patterns to relative paths within the root folder', async () => {
+            await projectView.toggle()
 
-          expect(Array.from(projectView.element.querySelectorAll('li')).find(a => a.textContent.includes('file.txt'))).toBeDefined()
+            await waitForPathsToDisplay(projectView)
+
+            expect(Array.from(projectView.element.querySelectorAll('li')).find(a => a.textContent.includes('file.txt'))).toBeDefined()
+          })
         })
       })
     })
-  })
+  }
 })


### PR DESCRIPTION
## Summary

This PR contains some minimal changes to demonstrate the usage of `ripgrep` on the fuzzy finder, so we can discuss the tradeoffs and steps needed to be able to ship this.

This work comes as a follow-up from https://github.com/atom/fuzzy-finder/pull/367 after the suggestions of @smashwilson .

## Benefits

Using `ripgrep` speeds up drastically the time to crawl medium and large repositories (we're taking about **up to 14X faster times**):

| Type | Num Files | Time (master)  | Time (This PR) | Improvements  |
|---|---|---|---|---|
|  Small | 2K  | 1.3s  | 0.9s | **30%** less time (or **1.4X** faster)  🎉 |
|  Medium |  30K | 6.2s  | 1.2s  | **80%** less time (or **5X** faster) 🎉 |
|  Large | 270K  |  57.5s  |  4.1s  |  **93%** less time (or **14X** faster) 🎉 |

(the measurement has been done the same way as in https://github.com/atom/fuzzy-finder/pull/366).

## Possible Drawbacks

The crawling behaviour with `ripgrep` is slightly different than the one currently implemented. I don't think that the changes are important enough (or even bad), but it's important to list them:

1. `ripgrep` also returns symlink destination files (e.g if there's a symlink `./foo.js` which points to `./bar.js`, with `ripgrep` `foo.js` can also be opened. I think this is an improvement.
2. The ordering of the returned results is slightly different: right now results are returned in a DFS ordering (then alphabetically), while `ripgrep` returns all results alphabetically ordered.
3. Currently, if Atom gets opened from a non-git folder which has git repositories in some sub-folders, the `.gitignore` files from the sub-folders are ignored. With `ripgrep` they are taken into account. I think that this is an improvement.

Regarding 2., this change is quite noticeable, since the fuzzy finder currently displays the first 10 files returned by the crawler when it gets opened. This means that the first shown files will be slightly different than before (IMO we should change the default list of files that are shown when opening the fuzzy finder to show e.g recently opened files or currently opened files).

## Alternate Designs

Other potential designs were presented [here](https://github.com/atom/fuzzy-finder/pull/367), and seems like `ripgrep` is the best tool to use at this moment.

Regarding the current implementation, I've decided to use [`vscode-ripgrep`](https://github.com/roblourens/vscode-ripgrep), which is just a package that handles the download of the `ripgrep` binaries for several platforms. This has saved me a ton of time, but I'm not familiar enough with the process to install bundled extensions in Atom to know if this  package is suitable for the job.

## Next steps

- [x] Write some automated tests to verify the `ripgrep` crawling.
- [x] Manually check that `ripgrep` works well on different scenarios.
  - [x] Different types of file system (FAT, NTFS, ...).
  - [x] Different OSes (Windows).
  - [x] Check that the `ripgrep` binary can be used correctly from a production build (e.g does the asar packaging cause any issue?).
    - [x] OSX
    - [x] Windows
- [x] Check that the behaviour is correct.
  - [x] Files/folders with utf8 names.
  - [x] List of returned files is the same in a few different repos. 

## Applicable Issues

 https://github.com/atom/fuzzy-finder/issues/271
