### PR TITLE
Start logging the time to index a project

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -1,0 +1,24 @@
+# Events specification
+
+This document specifies all the data (along with the format) which gets send from the Fuzzy Finder package to the GitHub analytics pipeline. This document follows the same format and nomenclature than the [Atom Core Events spec](https://github.com/atom/metrics/blob/master/docs/events.md).
+
+## Counters
+
+Currently the Fuzzy finder does not log any counter event.
+
+## Timing events
+
+#### Time to crawl the project
+
+* **eventType**: `fuzzy-finder-v1`
+* **metadata**
+
+  | field | value |
+  |-------|-------|
+  | `ec` | `time-to-crawl`
+  | `el` | Crawler type (`ripgrep` or `fs`)
+  | `ev` | Number of crawled files
+
+## Standard events
+
+Currently the Fuzzy Finder does not log any standard event.

--- a/docs/events.md
+++ b/docs/events.md
@@ -1,10 +1,10 @@
 # Events specification
 
-This document specifies all the data (along with the format) which gets send from the Fuzzy Finder package to the GitHub analytics pipeline. This document follows the same format and nomenclature than the [Atom Core Events spec](https://github.com/atom/metrics/blob/master/docs/events.md).
+This document specifies all the data (along with the format) which gets sent from the Fuzzy Finder package to the GitHub analytics pipeline. This document follows the same format and nomenclature as the [Atom Core Events spec](https://github.com/atom/metrics/blob/master/docs/events.md).
 
 ## Counters
 
-Currently the Fuzzy finder does not log any counter event.
+Currently the Fuzzy finder does not log any counter events.
 
 ## Timing events
 
@@ -21,4 +21,4 @@ Currently the Fuzzy finder does not log any counter event.
 
 ## Standard events
 
-Currently the Fuzzy Finder does not log any standard event.
+Currently the Fuzzy Finder does not log any standard events.

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,5 +1,8 @@
 const {CompositeDisposable, Disposable} = require('atom')
 const getIconServices = require('./get-icon-services')
+const ReporterProxy = require('./reporter-proxy')
+
+const metricsReporter = new ReporterProxy()
 
 module.exports = {
   activate (state) {
@@ -68,6 +71,12 @@ module.exports = {
     if (this.projectView) this.projectView.setTeletypeService(teletypeService)
   },
 
+  consumeMetricsReporter (metricsReporterService) {
+    metricsReporter.setReporter(metricsReporterService)
+
+    return new Disposable(() => metricsReporter.unsetReporter())
+  },
+
   serialize () {
     const paths = {}
     for (let editor of atom.workspace.getTextEditors()) {
@@ -82,7 +91,7 @@ module.exports = {
 
     if (this.projectView == null) {
       const ProjectView = require('./project-view')
-      this.projectView = new ProjectView(this.projectPaths)
+      this.projectView = new ProjectView(this.projectPaths, metricsReporter)
       this.projectPaths = null
       if (this.teletypeService) {
         this.projectView.setTeletypeService(this.teletypeService)
@@ -119,7 +128,7 @@ module.exports = {
     const PathLoader = require('./path-loader')
     this.loadPathsTask = PathLoader.startTask((projectPaths) => {
       this.projectPaths = projectPaths
-    })
+    }, metricsReporter)
     this.projectPathsSubscription = atom.project.onDidChangePaths(() => {
       this.projectPaths = null
       this.stopLoadPathsTask()

--- a/lib/path-loader.js
+++ b/lib/path-loader.js
@@ -2,7 +2,7 @@ const fs = require('fs-plus')
 const {Task} = require('atom')
 
 module.exports = {
-  startTask (callback) {
+  startTask (callback, metricsReporter) {
     const results = []
     const taskPath = require.resolve('./load-paths-handler')
     const followSymlinks = atom.config.get('core.followSymlinks')
@@ -12,6 +12,8 @@ module.exports = {
     const projectPaths = atom.project.getPaths().map((path) => fs.realpathSync(path))
     const useRipGrep = atom.config.get('fuzzy-finder.useRipGrep')
 
+    const startTime = performance.now()
+
     const task = Task.once(
       taskPath,
       projectPaths,
@@ -19,7 +21,15 @@ module.exports = {
       ignoreVcsIgnores,
       ignoredNames,
       useRipGrep,
-      () => callback(results)
+      () => {
+        callback(results)
+
+        const duration = Math.round(performance.now() - startTime)
+        const numFiles = results.length
+        const crawlerType = useRipGrep ? 'ripgrep' : 'fs'
+
+        metricsReporter.sendCrawlEvent(duration, numFiles, crawlerType)
+      }
     )
 
     task.on('load-paths:paths-found',

--- a/lib/project-view.js
+++ b/lib/project-view.js
@@ -6,12 +6,13 @@ const PathLoader = require('./path-loader')
 
 module.exports =
 class ProjectView extends FuzzyFinderView {
-  constructor (paths) {
+  constructor (paths, metricsReporter) {
     super()
     this.disposables = new CompositeDisposable()
     this.paths = paths
     this.reloadPaths = !this.paths || this.paths.length === 0
     this.reloadAfterFirstLoad = false
+    this.metricsReporter = metricsReporter
 
     const windowFocused = () => {
       if (this.paths) {
@@ -178,7 +179,8 @@ class ProjectView extends FuzzyFinderView {
       if (fn) {
         fn()
       }
-    })
+    }, this.metricsReporter)
+
     return this.loadPathsTask
   }
 }

--- a/lib/reporter-proxy.js
+++ b/lib/reporter-proxy.js
@@ -1,0 +1,35 @@
+
+module.exports = class ReporterProxy {
+  constructor () {
+    this.reporter = null
+    this.queue = []
+
+    this.eventType = 'fuzzy-finder-v1'
+  }
+
+  setReporter (reporter) {
+    this.reporter = reporter
+    let customEvent
+    while ((customEvent = this.queue.shift())) {
+      this.reporter.addCustomEvent(customEvent.category, customEvent)
+    }
+  }
+
+  unsetReporter () {
+    delete this.reporter
+  }
+
+  sendCrawlEvent (duration, numFiles, crawlerType) {
+    const metadata = {
+      ec: 'time-to-crawl',
+      el: crawlerType,
+      ev: numFiles
+    }
+
+    if (this.reporter) {
+      this.reporter.addTiming(this.eventType, duration, metadata)
+    } else {
+      this.queue.push([event])
+    }
+  }
+}

--- a/lib/reporter-proxy.js
+++ b/lib/reporter-proxy.js
@@ -1,16 +1,17 @@
 module.exports = class ReporterProxy {
   constructor () {
     this.reporter = null
-    this.queue = []
+    this.timingsQueue = []
 
     this.eventType = 'fuzzy-finder-v1'
   }
 
   setReporter (reporter) {
     this.reporter = reporter
-    let customEvent
-    while ((customEvent = this.queue.shift())) {
-      this.reporter.addCustomEvent(customEvent.category, customEvent)
+    let timingsEvent
+
+    while ((timingsEvent = this.timingsQueue.shift())) {
+      this.reporter.addTiming(this.eventType, timingsEvent[0], timingsEvent[1])
     }
   }
 
@@ -25,10 +26,14 @@ module.exports = class ReporterProxy {
       ev: numFiles
     }
 
+    this._addTiming(duration, metadata)
+  }
+
+  _addTiming (duration, metadata) {
     if (this.reporter) {
       this.reporter.addTiming(this.eventType, duration, metadata)
     } else {
-      this.queue.push([event])
+      this.timingsQueue.push([duration, metadata])
     }
   }
 }

--- a/lib/reporter-proxy.js
+++ b/lib/reporter-proxy.js
@@ -1,4 +1,3 @@
-
 module.exports = class ReporterProxy {
   constructor () {
     this.reporter = null

--- a/package.json
+++ b/package.json
@@ -54,6 +54,11 @@
       "versions": {
         "1.0.0": "consumeElementIcons"
       }
+    },
+    "metrics-reporter": {
+      "versions": {
+        "^1.1.0": "consumeMetricsReporter"
+      }
     }
   },
   "configSchema": {

--- a/spec/project-view-spec.js
+++ b/spec/project-view-spec.js
@@ -3,6 +3,9 @@ const fs = require('fs')
 const path = require('path')
 const temp = require('temp').track()
 const ProjectView = require('../lib/project-view')
+const ReporterProxy = require('../lib/reporter-proxy')
+
+const metricsReporter = new ReporterProxy()
 
 describe('ProjectView', () => {
   beforeEach(() => {
@@ -10,7 +13,7 @@ describe('ProjectView', () => {
   })
 
   it('includes remote editors when teletype is enabled', async () => {
-    const projectView = new ProjectView()
+    const projectView = new ProjectView([], metricsReporter)
 
     const projectPath = fs.realpathSync(temp.mkdirSync())
     const file1Path = path.join(projectPath, 'a')
@@ -39,7 +42,7 @@ describe('ProjectView', () => {
   })
 
   it('shows remote editors even when there is no open project', async () => {
-    const projectView = new ProjectView()
+    const projectView = new ProjectView([], metricsReporter)
 
     atom.project.setPaths([])
     projectView.setTeletypeService({
@@ -59,7 +62,7 @@ describe('ProjectView', () => {
   })
 
   it('gracefully defaults to empty list if teletype is unable to provide remote editors', async () => {
-    const projectView = new ProjectView()
+    const projectView = new ProjectView([], metricsReporter)
 
     atom.project.setPaths([])
     projectView.setTeletypeService({


### PR DESCRIPTION
### Description of the Change

This PR makes use of the `atom/metrics` package to be able to start logging the time it takes to index a project by the fuzzy finder.

The format of the data that's being logged is the following:

* **eventType**: `fuzzy-finder-v1`
* **metadata**

  | field | value |
  |-------|-------|
  | `ec` | `time-to-crawl`
  | `el` | Crawler type (`ripgrep` or `fs`)
  | `ev` | Number of crawled files

Sample payload

```json
{
  "eventType": "fuzzy-finder-v1",
  "durationInMilliseconds": 539,
  "metadata": {
    "ec": "time-to-crawl",
    "el": "ripgrep",
    "ev": 49,
    "cd2": "x64",
    "cd3": "x64",
    "cm1": 180,
    "cm2": 83,
    "sr": "1680x1050",
    "vp": "1680x591",
    "aiid": "dev"
  },
  "date": "2019-03-21T17:05:32.706Z"
}
```

### Test plan

- [x] Check that `atom/telemetry` sends the correct payload to GitHub's backend. To do so, I've had to edit the code of the `atom/telemetry` package (more specifically, I've manually modified `node_modules/telemetry-github/out/index.js` to set the variable `this.isDevMode` to `false` ([code](https://github.com/atom/telemetry/blob/master/src/index.ts#L108)). I've also had to increase how often Atom sends metrics, since by default it only sends them every 24 hours. To do so, I've set the variables `DailyStatsReportIntervalInMs` and `ReportingLoopIntervalInMs` located in the previous file to something like `15000` ([code](https://github.com/atom/telemetry/blob/master/src/index.ts#L20-L23)).
- [x] Check that the data gets propagated correctly to our analytics pipeline.

### Alternate Designs

Do not log this?

### Benefits

Knowing the time it takes to crawl the project by the fuzzy finder on real users will help us decide how much effort should be put on improving its performance.

### Possible Drawbacks

We're logging a little bit more data from users.

### Applicable Issues

https://github.com/atom/fuzzy-finder/issues/371

/cc @telliott27 