### PR TITLE
Do not call `setItems()` every time that the fuzzy finder is shown

### DIFF
--- a/lib/project-view.js
+++ b/lib/project-view.js
@@ -34,6 +34,10 @@ class ProjectView extends FuzzyFinderView {
       this.reloadPaths = true
       this.paths = null
     }))
+
+    if (!this.reloadPaths) {
+      this.populate()
+    }
   }
 
   destroy () {
@@ -54,7 +58,7 @@ class ProjectView extends FuzzyFinderView {
       this.cancel()
     } else {
       this.show()
-      await this.populate()
+      await this.reloadPathsIfNeeded()
     }
   }
 
@@ -70,17 +74,19 @@ class ProjectView extends FuzzyFinderView {
       }
     })
 
-    if (atom.project.getPaths().length === 0) {
-      await this.setItems(remoteItems)
-      return
-    }
-
     const localItems = this.projectRelativePathsForFilePaths(this.paths || [])
     await this.setItems(remoteItems.concat(localItems))
+  }
 
+  async reloadPathsIfNeeded () {
     if (this.reloadPaths) {
       this.reloadPaths = false
       let task = null
+
+      if (atom.project.getPaths().length === 0) {
+        return this.populate()
+      }
+
       try {
         task = this.runLoadPathsTask(() => {
           if (this.reloadAfterFirstLoad) {

--- a/spec/fuzzy-finder-spec.js
+++ b/spec/fuzzy-finder-spec.js
@@ -71,6 +71,12 @@ describe('FuzzyFinder', () => {
     return conditionPromise(() => fuzzyFinderView.element.querySelectorAll('li').length > 0)
   }
 
+  async function waitForReCrawlerToFinish (fuzzyFinderView) {
+    return conditionPromise(
+      () => !fuzzyFinderView.element.querySelector('.loading .loading-message')
+    )
+  }
+
   function eachFilePath (dirPaths, fn) {
     for (let dirPath of dirPaths) {
       wrench.readdirSyncRecursive(dirPath).filter((filePath) => {
@@ -734,6 +740,9 @@ describe('FuzzyFinder', () => {
           await projectView.toggle()
 
           expect(PathLoader.startTask).toHaveBeenCalled()
+
+          await waitForReCrawlerToFinish(projectView)
+
           expect(projectView.element.querySelectorAll('li').length).toBe(0)
         })
 

--- a/spec/project-view-spec.js
+++ b/spec/project-view-spec.js
@@ -1,6 +1,8 @@
 const {it, fit, ffit, fffit, beforeEach, afterEach, conditionPromise} = require('./async-spec-helpers')  // eslint-disable-line no-unused-vars
 const fs = require('fs')
+const os = require('os')
 const path = require('path')
+const sinon = require('sinon')
 const temp = require('temp').track()
 const ProjectView = require('../lib/project-view')
 const ReporterProxy = require('../lib/reporter-proxy')
@@ -10,6 +12,13 @@ const metricsReporter = new ReporterProxy()
 describe('ProjectView', () => {
   beforeEach(() => {
     jasmine.useRealClock()
+
+    // Limit concurrency on the crawler to avoid indeterminism.
+    sinon.stub(os, 'cpus').returns({length: 1})
+  })
+
+  afterEach(() => {
+    os.cpus.restore()
   })
 
   it('includes remote editors when teletype is enabled', async () => {


### PR DESCRIPTION
### Description of the Change

This PR unblocks the work to use `native-fuzzy` to improve the filtering performance by mitigating one of [its concerns](https://github.com/atom/fuzzy-finder/issues/370#issuecomment-477246644).

Basically, before this PR the UI was blocked by the execution of the `setItems()` method every time the fuzzy finder was shown (and it delayed its appearance in the UI). This was not a big problem before because the `setItems()` method used to be quite fast, but with the addition of `native-fuzzy` we need to do more expensive things here (we need to serialize and pass the whole list of items to the `native-fuzzy`).

### Alternate Designs

N/A

### Benefits

* Unblocking a big performance improvement.
* Less work done every time the fuzzy finder is opened

### Possible Drawbacks

N/A

### Applicable Issues

https://github.com/atom/fuzzy-finder/issues/370
