### PR TITLE
Add metrics for fuzzy-finder filtering time

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -19,6 +19,17 @@ Currently the Fuzzy finder does not log any counter events.
   | `el` | Crawler type (`ripgrep` or `fs`)
   | `ev` | Number of crawled files
 
+#### Time to filter results
+
+* **eventType**: `fuzzy-finder-v1`
+* **metadata**
+
+  | field | value |
+  |-------|-------|
+  | `ec` | `time-to-filter`
+  | `el` | Scoring system (`alternate` or `fast`)
+  | `ev` | Number of items in the list
+
 ## Standard events
 
 Currently the Fuzzy Finder does not log any standard events.

--- a/lib/fuzzy-finder-view.js
+++ b/lib/fuzzy-finder-view.js
@@ -23,10 +23,11 @@ const SCORING_SYSTEMS = {
 const MAX_RESULTS = 10
 
 module.exports = class FuzzyFinderView {
-  constructor () {
+  constructor (metricsReporter) {
     this.previousQueryWasLineJump = false
     this.items = []
     this.filterFn = this.filterFn.bind(this)
+    this.metricsReporter = metricsReporter
 
     this.selectListView = new SelectListView({
       items: this.items,
@@ -394,13 +395,22 @@ module.exports = class FuzzyFinderView {
       return items
     }
 
+    let results
+    const startTime = performance.now()
+
     if (this.scoringSystem === SCORING_SYSTEMS.FAST) {
-      return this.nativeFuzzy.match(query, {maxResults: MAX_RESULTS}).map(
+      results = this.nativeFuzzy.match(query, {maxResults: MAX_RESULTS}).map(
         result => this.convertPathToSelectViewObject(this.getAbsolutePath(result.value))
       )
+    } else {
+      results = fuzzaldrinPlus.filter(items, query, {key: 'label'})
     }
 
-    return fuzzaldrinPlus.filter(items, query, {key: 'label'})
+    const duration = Math.round(performance.now() - startTime)
+
+    this.metricsReporter.sendFilterEvent(duration, items.length, this.scoringSystem)
+
+    return results
   }
 }
 

--- a/lib/fuzzy-finder-view.js
+++ b/lib/fuzzy-finder-view.js
@@ -26,6 +26,7 @@ module.exports = class FuzzyFinderView {
   constructor () {
     this.previousQueryWasLineJump = false
     this.items = []
+    this.filterFn = this.filterFn.bind(this)
 
     this.selectListView = new SelectListView({
       items: this.items,
@@ -164,23 +165,9 @@ module.exports = class FuzzyFinderView {
             this.nativeFuzzyForResults = new NativeFuzzy.Matcher([])
           }
 
-          this.selectListView.update({
-            filter: (items, query) => {
-              if (!query) {
-                return items
-              }
-
-              return this.nativeFuzzy.match(query, {maxResults: MAX_RESULTS}).map(
-                result => this.convertPathToSelectViewObject(this.getAbsolutePath(result.value))
-              )
-            }
-          })
+          this.selectListView.update({ filter: this.filterFn })
         } else {
-          this.selectListView.update({
-            filter: (items, query) => {
-              return query ? fuzzaldrinPlus.filter(items, query, {key: 'label'}) : items
-            }
-          })
+          this.selectListView.update({ filter: this.filterFn })
         }
       })
     )
@@ -400,6 +387,20 @@ module.exports = class FuzzyFinderView {
 
     // Best effort: just return the relative path.
     return relativePath
+  }
+
+  filterFn (items, query) {
+    if (!query) {
+      return items
+    }
+
+    if (this.scoringSystem === SCORING_SYSTEMS.FAST) {
+      return this.nativeFuzzy.match(query, {maxResults: MAX_RESULTS}).map(
+        result => this.convertPathToSelectViewObject(this.getAbsolutePath(result.value))
+      )
+    }
+
+    return fuzzaldrinPlus.filter(items, query, {key: 'label'})
   }
 }
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -111,7 +111,7 @@ module.exports = {
   createBufferView () {
     if (this.bufferView == null) {
       const BufferView = require('./buffer-view')
-      this.bufferView = new BufferView()
+      this.bufferView = new BufferView(metricsReporter)
       if (this.teletypeService) {
         this.bufferView.setTeletypeService(this.teletypeService)
       }

--- a/lib/project-view.js
+++ b/lib/project-view.js
@@ -7,12 +7,11 @@ const PathLoader = require('./path-loader')
 module.exports =
 class ProjectView extends FuzzyFinderView {
   constructor (paths, metricsReporter) {
-    super()
+    super(metricsReporter)
     this.disposables = new CompositeDisposable()
     this.paths = paths
     this.reloadPaths = !this.paths || this.paths.length === 0
     this.reloadAfterFirstLoad = false
-    this.metricsReporter = metricsReporter
 
     const windowFocused = () => {
       if (this.paths) {

--- a/lib/reporter-proxy.js
+++ b/lib/reporter-proxy.js
@@ -1,9 +1,13 @@
+const _ = require('underscore-plus')
+
 module.exports = class ReporterProxy {
   constructor () {
     this.reporter = null
     this.timingsQueue = []
 
     this.eventType = 'fuzzy-finder-v1'
+
+    this._addTimingThrottled = _.throttle(this._addTiming.bind(this), 60 * 1000)
   }
 
   setReporter (reporter) {
@@ -16,6 +20,8 @@ module.exports = class ReporterProxy {
   }
 
   unsetReporter () {
+    this._addTimingThrottled.cancel()
+
     delete this.reporter
   }
 
@@ -36,7 +42,7 @@ module.exports = class ReporterProxy {
       ev: numFiles
     }
 
-    this._addTiming(duration, metadata)
+    this._addTimingThrottled(duration, metadata)
   }
 
   _addTiming (duration, metadata) {

--- a/lib/reporter-proxy.js
+++ b/lib/reporter-proxy.js
@@ -29,6 +29,16 @@ module.exports = class ReporterProxy {
     this._addTiming(duration, metadata)
   }
 
+  sendFilterEvent (duration, numFiles, scoringSystem) {
+    const metadata = {
+      ec: 'time-to-filter',
+      el: scoringSystem,
+      ev: numFiles
+    }
+
+    this._addTiming(duration, metadata)
+  }
+
   _addTiming (duration, metadata) {
     if (this.reporter) {
       this.reporter.addTiming(this.eventType, duration, metadata)

--- a/package-lock.json
+++ b/package-lock.json
@@ -2456,16 +2456,16 @@
       "dev": true
     },
     "underscore": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-      "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
+      "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
     },
     "underscore-plus": {
-      "version": "1.6.8",
-      "resolved": "https://registry.npmjs.org/underscore-plus/-/underscore-plus-1.6.8.tgz",
-      "integrity": "sha512-88PrCeMKeAAC1L4xjSiiZ3Fg6kZOYrLpLGVPPeqKq/662DfQe/KTSKdSR/Q/tucKNnfW2MNAUGSCkDf8HmXC5Q==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/underscore-plus/-/underscore-plus-1.7.0.tgz",
+      "integrity": "sha512-A3BEzkeicFLnr+U/Q3EyWwJAQPbA19mtZZ4h+lLq3ttm9kn8WC4R3YpuJZEXmWdLjYP47Zc8aLZm9kwdv+zzvA==",
       "requires": {
-        "underscore": "~1.8.3"
+        "underscore": "^1.9.1"
       }
     },
     "uniq": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "humanize-plus": "~1.8.2",
     "minimatch": "~3.0.3",
     "temp": "~0.8.1",
-    "underscore-plus": "^1.0.0",
+    "underscore-plus": "^1.7.0",
     "vscode-ripgrep": "^1.2.5",
     "wrench": "^1.5"
   },

--- a/spec/fuzzy-finder-spec.js
+++ b/spec/fuzzy-finder-spec.js
@@ -1666,22 +1666,26 @@ describe('FuzzyFinder', () => {
 
               disposable = fuzzyFinderPackage.consumeMetricsReporter(reporterStub)
 
+              await projectView.toggle()
+              await waitForPathsToDisplay(projectView)
+
               // After setting the reporter it may receive some old events from previous tests
               // that we want to discard.
               reporterStub.addTiming.reset()
 
-              await projectView.toggle()
-
-              await waitForPathsToDisplay(projectView)
-
               projectView.selectListView.refs.queryEditor.setText('anything')
-
               await getOrScheduleUpdatePromise()
 
               expect(reporterStub.addTiming.lastCall.args[0]).toEqual('fuzzy-finder-v1')
               expect(reporterStub.addTiming.lastCall.args[2]).toEqual(
                 {ec: 'time-to-filter', el: scoringSystem, ev: 5}
               )
+
+              // Check that events are throttled
+              await projectView.selectListView.refs.queryEditor.setText('anything else')
+              await getOrScheduleUpdatePromise()
+
+              expect(reporterStub.addTiming.getCalls().length).toBe(1)
             })
           }
         })

--- a/spec/fuzzy-finder-spec.js
+++ b/spec/fuzzy-finder-spec.js
@@ -1655,6 +1655,35 @@ describe('FuzzyFinder', () => {
               {ec: 'time-to-crawl', el: useRipGrep ? 'ripgrep' : 'fs', ev: 5}
             )
           })
+
+          // We're not logging events when using the standard scoring system (since that one
+          // is not controlled by the fuzzy-finder).
+          if (scoringSystem !== 'standard') {
+            it('logs the filtering time', async () => {
+              const reporterStub = {
+                addTiming: sinon.spy()
+              }
+
+              disposable = fuzzyFinderPackage.consumeMetricsReporter(reporterStub)
+
+              // After setting the reporter it may receive some old events from previous tests
+              // that we want to discard.
+              reporterStub.addTiming.reset()
+
+              await projectView.toggle()
+
+              await waitForPathsToDisplay(projectView)
+
+              projectView.selectListView.refs.queryEditor.setText('anything')
+
+              await getOrScheduleUpdatePromise()
+
+              expect(reporterStub.addTiming.lastCall.args[0]).toEqual('fuzzy-finder-v1')
+              expect(reporterStub.addTiming.lastCall.args[2]).toEqual(
+                {ec: 'time-to-filter', el: scoringSystem, ev: 5}
+              )
+            })
+          }
         })
       })
     })


### PR DESCRIPTION
### Summary

In order to understand better the real world performance of the `fuzzy-finder` and allow us to take better decisions, we want to start logging the time it takes to execute a filtering action.

Along with the time taken to do the filtering, we want to log some additional metadata:

* **Number of files in the repository**: the time will vary a lot depending on the project size so we need to be able to filter results by similar project sizes.
* **Scoring system**: Our hypothesis is that the new `fast` scoring system implemented [here](https://github.com/atom/fuzzy-finder/pull/374) will have an important impact on the filtering time, so we want to log which is the scoring type that's being used.

Since the `standard` scoring system is not controlled by the fuzzy finder (but via `atom-select-list`) we cannot easily log it from here. That's not a big deal since we're planning on deprecating that system.

### Schema of the data

* **eventType**: `fuzzy-finder-v1`
* **metadata**

  | field | value |
  |-------|-------|
  | `ec` | `time-to-filter`
  | `el` | Scoring type (`alternate` or `fast`)
  | `ev` | Number of files in the project

Sample JSON payload

```json
{
  "eventType": "fuzzy-finder-v1",
  "durationInMilliseconds": 539,
  "metadata": {
    "ec": "time-to-filter",
    "el": "fast",
    "ev": 789,
    "cd2": "x64",
    "cd3": "x64",
    "cm1": 180,
    "cm2": 83,
    "sr": "1680x1050",
    "vp": "1680x591",
    "aiid": "dev"
  },
  "date": "2019-03-21T17:05:32.706Z"
}
```

### Verification process

- [x] Check that Atom is sending the expected JSON payload to the GitHub backend systems by enabling the metrics debug mode.
- [x] Check that the the events get stored on our pipelines correctly.

//cc @telliott27 