### PR TITLE
Show prompt to enable "fast mode" on large projects

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -7,13 +7,13 @@ This document specifies all the data (along with the format) which gets sent fro
 | counter name | description |
 |-------|-------|
 | `show-enable-prompt` | Number of times the prompt to enable fast mode is shown |
-| `click-enable-prompt` | Number of clicks on the enable fast mode prompt |
-| `confirm-enable-prompt` | Number of confirmations on the enable fast mode notification |
-| `cancel-enable-prompt` | Number of cancels on the enable fast mode prompt |
+| `click-enable-prompt` | Number of clicks on the "enable fast mode" prompt |
+| `confirm-enable-prompt` | Number of confirmations on the "enable fast mode" notification |
+| `cancel-enable-prompt` | Number of cancels on the "enable fast mode" notification |
 | `show-disable-prompt` | Number of times the prompt to disable fast mode is shown |
-| `click-disable-prompt` | Number of clicks on the disable fast mode prompt |
-| `confirm-disable-prompt` | Number of confirmations on the disable fast mode notification |
-| `cancel-disable-prompt` | Number of cancels on the disable fast mode prompt |
+| `click-disable-prompt` | Number of clicks on the "disable fast mode" prompt |
+| `confirm-disable-prompt` | Number of confirmations on the "disable fast mode" notification |
+| `cancel-disable-prompt` | Number of cancels on the "disable fast mode" notification |
 
 ## Timing events
 

--- a/docs/events.md
+++ b/docs/events.md
@@ -4,7 +4,16 @@ This document specifies all the data (along with the format) which gets sent fro
 
 ## Counters
 
-Currently the Fuzzy finder does not log any counter events.
+| counter name | description |
+|-------|-------|
+| `show-enable-prompt` | Number of times the prompt to enable fast mode is shown |
+| `click-enable-prompt` | Number of clicks on the enable fast mode prompt |
+| `confirm-enable-prompt` | Number of confirmations on the enable fast mode notification |
+| `cancel-enable-prompt` | Number of cancels on the enable fast mode prompt |
+| `show-disable-prompt` | Number of times the prompt to disable fast mode is shown |
+| `click-disable-prompt` | Number of clicks on the disable fast mode prompt |
+| `confirm-disable-prompt` | Number of confirmations on the disable fast mode notification |
+| `cancel-disable-prompt` | Number of cancels on the disable fast mode prompt |
 
 ## Timing events
 

--- a/lib/experiment-prompt.js
+++ b/lib/experiment-prompt.js
@@ -108,8 +108,8 @@ function renderExperimentPrompt (metricsReporter) {
     return (
       $.span({className: 'experiment-prompt'}, [
         $.a({onmousedown: disableExperimentalFuzzyFinder.bind(null, metricsReporter)}, [
-          $.span({className: ''}, 'Having issues with the fast mode?'),
-          $.span({className: 'icon icon-rocket'}, '')
+          $.span({className: 'icon icon-rocket'}, ''),
+          $.span({className: ''}, 'Having issues with the fast mode?')
         ])
       ])
     )
@@ -121,8 +121,8 @@ function renderExperimentPrompt (metricsReporter) {
     $.span({className: 'experiment-prompt'}, [
       $.a({onmousedown: enableExperimentalFuzzyFinder.bind(null, metricsReporter)}, [
         shouldShowBadge() ? $.span({className: 'badge badge-info'}, 'NEW') : null,
-        $.span({className: ''}, 'Try experimental fast mode?'),
-        $.span({className: 'icon icon-beaker'}, '')
+        $.span({className: 'icon icon-beaker'}, ''),
+        $.span({className: ''}, 'Try experimental fast mode?')
       ])
     ])
   )

--- a/lib/experiment-prompt.js
+++ b/lib/experiment-prompt.js
@@ -122,7 +122,7 @@ function renderExperimentPrompt (metricsReporter) {
       $.a({onmousedown: enableExperimentalFuzzyFinder.bind(null, metricsReporter)}, [
         shouldShowBadge() ? $.span({className: 'badge badge-info'}, 'NEW') : null,
         $.span({className: ''}, 'Try experimental fast mode?'),
-        $.span({className: 'icon icon-microscope'}, '')
+        $.span({className: 'icon icon-beaker'}, '')
       ])
     ])
   )

--- a/lib/experiment-prompt.js
+++ b/lib/experiment-prompt.js
@@ -22,26 +22,25 @@ function shouldShowBadge () {
   return now - firstTimeShown <= TimeToShowNewBadge
 }
 
-function enableExperimentalFuzzyFinder () {
+function showNotification (message, {detail, confirmBtn, cancelBtn, confirmFn, cancelFn}) {
   const notification = atom.notifications.addInfo(
-    'The project you\'ve opened is quite large, which may cause performance issues on the quick open menu. Do you want to enable the new experimental fast mode for the quick open menu?',
+    message,
     {
-      detail: 'This mode can be disabled from the fuzzy finder settings later',
+      detail,
       dismissable: true,
       buttons: [
         {
-          text: 'Enable experimental fast mode',
+          text: confirmBtn,
           onDidClick: () => {
-            atom.config.set('fuzzy-finder.scoringSystem', SCORING_SYSTEMS.FAST)
-            atom.config.set('fuzzy-finder.useRipGrep', true)
-
+            confirmFn && confirmFn()
             notification.dismiss()
           },
           className: 'btn btn-info btn-primary'
         },
         {
-          text: 'No',
+          text: cancelBtn,
           onDidClick: () => {
+            cancelFn && cancelFn()
             notification.dismiss()
           }
         }
@@ -51,7 +50,56 @@ function enableExperimentalFuzzyFinder () {
   )
 }
 
+function enableExperimentalFuzzyFinder () {
+  showNotification(
+    'Do you want to enable the new experimental fast mode for the quick open menu?',
+    {
+      detail: 'This mode can be disabled from the fuzzy finder later',
+      confirmBtn: 'Enable experimental fast mode',
+      confirmFn: () => {
+        atom.config.set('fuzzy-finder.useRipGrep', true)
+        atom.config.set('fuzzy-finder.scoringSystem', SCORING_SYSTEMS.FAST)
+      },
+      cancelBtn: 'No, thanks',
+    }
+  )
+}
+
+function disableExperimentalFuzzyFinder () {
+  showNotification(
+    'Do you want to enable the new experimental fast mode for the quick open menu?',
+    {
+      detail: 'You can reenable it later from the fuzzy finder',
+      confirmBtn: 'Disable experimental fast mode',
+      confirmFn: () => {
+        atom.config.set('fuzzy-finder.useRipGrep', false)
+        atom.config.set('fuzzy-finder.scoringSystem', SCORING_SYSTEMS.ALTERNATE)
+      },
+      cancelBtn: 'No, thanks'
+    }
+  )
+}
+
+
+function isFastModeEnabled () {
+  return (
+    atom.config.get('fuzzy-finder.scoringSystem') === SCORING_SYSTEMS.FAST &&
+    atom.config.get('fuzzy-finder.useRipGrep') === true
+  )
+}
+
 function renderExperimentPrompt () {
+  if (isFastModeEnabled()) {
+    return (
+      $.span({className: 'experiment-prompt'}, [
+        $.a({onmousedown: disableExperimentalFuzzyFinder}, [
+          $.span({className: ''}, 'Having issues with the fast mode?'),
+          $.span({className: 'icon icon-rocket'}, '')
+        ])
+      ])
+    )
+  }
+
   return (
     $.span({className: 'experiment-prompt'}, [
       $.a({onmousedown: enableExperimentalFuzzyFinder}, [

--- a/lib/experiment-prompt.js
+++ b/lib/experiment-prompt.js
@@ -78,7 +78,7 @@ function disableExperimentalFuzzyFinder (metricsReporter) {
   showNotification(
     'Do you want to disable the new experimental fast mode for the fuzzy finder?',
     {
-      description: 'You can reenable it later from the fuzzy finder.',
+      description: 'If the experimental fast mode is negatively impacting your experience, please [**let us know**](https://github.com/atom/fuzzy-finder/issues/new?title=[Feedback]+Experimental+fast+mode).\n\n(You can reenable fast mode later from the fuzzy finder.)',
       confirmBtn: 'Disable experimental fast mode',
       confirmFn: () => {
         metricsReporter.incrementCounter('confirm-disable-prompt')

--- a/lib/experiment-prompt.js
+++ b/lib/experiment-prompt.js
@@ -109,7 +109,7 @@ function renderExperimentPrompt (metricsReporter) {
       $.span({className: 'experiment-prompt'}, [
         $.a({onmousedown: disableExperimentalFuzzyFinder.bind(null, metricsReporter)}, [
           $.span({className: 'icon icon-rocket'}, ''),
-          $.span({className: ''}, 'Having issues with the fast mode?')
+          $.span({className: ''}, 'Using experimental fast mode. Opt out?'),
         ])
       ])
     )

--- a/lib/experiment-prompt.js
+++ b/lib/experiment-prompt.js
@@ -15,6 +15,11 @@ const TimeToShowNewBadgeInMilliseconds = 24 * 60 * 60 * 1000
 const FirstTimeShownKey = 'fuzzy-finder:prompt-first-time-shown'
 
 function shouldShowPrompt (numItems) {
+  // The nucleus-dark-ui does not display the prompt correctly.
+  if (atom.themes.getActiveThemeNames().includes('nucleus-dark-ui')) {
+    return false
+  }
+
   return isFastModeEnabled() || numItems > ThresholdForShowingPrompt
 }
 

--- a/lib/experiment-prompt.js
+++ b/lib/experiment-prompt.js
@@ -15,7 +15,7 @@ const TimeToShowNewBadgeInMilliseconds = 24 * 60 * 60 * 1000
 const FirstTimeShownKey = 'fuzzy-finder:prompt-first-time-shown'
 
 function shouldShowPrompt (numItems) {
-  return numItems > ThresholdForShowingPrompt
+  return isFastModeEnabled() || numItems > ThresholdForShowingPrompt
 }
 
 function shouldShowBadge () {

--- a/lib/experiment-prompt.js
+++ b/lib/experiment-prompt.js
@@ -60,7 +60,7 @@ function enableExperimentalFuzzyFinder () {
         atom.config.set('fuzzy-finder.useRipGrep', true)
         atom.config.set('fuzzy-finder.scoringSystem', SCORING_SYSTEMS.FAST)
       },
-      cancelBtn: 'No, thanks',
+      cancelBtn: 'No, thanks'
     }
   )
 }
@@ -79,7 +79,6 @@ function disableExperimentalFuzzyFinder () {
     }
   )
 }
-
 
 function isFastModeEnabled () {
   return (

--- a/lib/experiment-prompt.js
+++ b/lib/experiment-prompt.js
@@ -63,6 +63,7 @@ function enableExperimentalFuzzyFinder (metricsReporter) {
 
         atom.config.set('fuzzy-finder.useRipGrep', true)
         atom.config.set('fuzzy-finder.scoringSystem', SCORING_SYSTEMS.FAST)
+        atom.notifications.addSuccess('Fasten your seatbelt! Here comes a faster fuzzy finder.', {icon: 'rocket'})
       },
       cancelBtn: 'Not right now',
       cancelFn: () => {
@@ -85,6 +86,7 @@ function disableExperimentalFuzzyFinder (metricsReporter) {
 
         atom.config.set('fuzzy-finder.useRipGrep', false)
         atom.config.set('fuzzy-finder.scoringSystem', SCORING_SYSTEMS.ALTERNATE)
+        atom.notifications.addSuccess('OK. Experimental fast mode is disabled.')
       },
       cancelBtn: 'No, thanks',
       cancelFn: () => {

--- a/lib/experiment-prompt.js
+++ b/lib/experiment-prompt.js
@@ -22,11 +22,11 @@ function shouldShowBadge () {
   return now - firstTimeShown <= TimeToShowNewBadgeInMilliseconds
 }
 
-function showNotification (message, {detail, confirmBtn, cancelBtn, confirmFn, cancelFn}) {
+function showNotification (message, {description, confirmBtn, cancelBtn, confirmFn, cancelFn}) {
   const notification = atom.notifications.addInfo(
     message,
     {
-      detail,
+      description,
       dismissable: true,
       buttons: [
         {
@@ -54,17 +54,17 @@ function enableExperimentalFuzzyFinder (metricsReporter) {
   metricsReporter.incrementCounter('click-enable-prompt')
 
   showNotification(
-    'Do you want to enable the new experimental fast mode for the quick open menu?',
+    'Introducing experimental fast mode',
     {
-      detail: 'This mode can be disabled from the fuzzy finder later',
-      confirmBtn: 'Enable experimental fast mode',
+      description: "The fuzzy finder has a new experimental _fast mode_. It dramatically speeds up the experience of finding files, especially in large projects. Would you like to try it?\n\n(You can always switch back to the fuzzy finder's _normal mode_ later.)",
+      confirmBtn: 'Enable fast mode',
       confirmFn: () => {
         metricsReporter.incrementCounter('confirm-enable-prompt')
 
         atom.config.set('fuzzy-finder.useRipGrep', true)
         atom.config.set('fuzzy-finder.scoringSystem', SCORING_SYSTEMS.FAST)
       },
-      cancelBtn: 'No, thanks',
+      cancelBtn: 'Not right now',
       cancelFn: () => {
         metricsReporter.incrementCounter('cancel-enable-prompt')
       }
@@ -76,9 +76,9 @@ function disableExperimentalFuzzyFinder (metricsReporter) {
   metricsReporter.incrementCounter('click-disable-prompt')
 
   showNotification(
-    'Do you want to disable the new experimental fast mode for the quick open menu?',
+    'Do you want to disable the new experimental fast mode for the fuzzy finder?',
     {
-      detail: 'You can reenable it later from the fuzzy finder',
+      description: 'You can reenable it later from the fuzzy finder.',
       confirmBtn: 'Disable experimental fast mode',
       confirmFn: () => {
         metricsReporter.incrementCounter('confirm-disable-prompt')

--- a/lib/experiment-prompt.js
+++ b/lib/experiment-prompt.js
@@ -93,7 +93,7 @@ function disableExperimentalFuzzyFinder (metricsReporter) {
   showNotification(
     'Do you want to disable the new experimental fast mode for the fuzzy finder?',
     {
-      description: 'If the experimental fast mode is negatively impacting your experience, please [**let us know**](https://github.com/atom/fuzzy-finder/issues/new?title=[Feedback]+Experimental+fast+mode).\n\n(You can reenable fast mode later from the fuzzy finder.)',
+      description: 'If the experimental fast mode is negatively impacting your experience, please leave a comment to [**let us know**](https://github.com/atom/fuzzy-finder/issues/379).\n\n(You can reenable fast mode later from the fuzzy finder.)',
       confirmBtn: 'Disable experimental fast mode',
       confirmFn: () => {
         metricsReporter.incrementCounter('confirm-disable-prompt')

--- a/lib/experiment-prompt.js
+++ b/lib/experiment-prompt.js
@@ -50,32 +50,46 @@ function showNotification (message, {detail, confirmBtn, cancelBtn, confirmFn, c
   )
 }
 
-function enableExperimentalFuzzyFinder () {
+function enableExperimentalFuzzyFinder (metricsReporter) {
+  metricsReporter.incrementCounter('click-enable-prompt')
+
   showNotification(
     'Do you want to enable the new experimental fast mode for the quick open menu?',
     {
       detail: 'This mode can be disabled from the fuzzy finder later',
       confirmBtn: 'Enable experimental fast mode',
       confirmFn: () => {
+        metricsReporter.incrementCounter('confirm-enable-prompt')
+
         atom.config.set('fuzzy-finder.useRipGrep', true)
         atom.config.set('fuzzy-finder.scoringSystem', SCORING_SYSTEMS.FAST)
       },
-      cancelBtn: 'No, thanks'
+      cancelBtn: 'No, thanks',
+      cancelFn: () => {
+        metricsReporter.incrementCounter('cancel-enable-prompt')
+      }
     }
   )
 }
 
-function disableExperimentalFuzzyFinder () {
+function disableExperimentalFuzzyFinder (metricsReporter) {
+  metricsReporter.incrementCounter('click-disable-prompt')
+
   showNotification(
     'Do you want to enable the new experimental fast mode for the quick open menu?',
     {
       detail: 'You can reenable it later from the fuzzy finder',
       confirmBtn: 'Disable experimental fast mode',
       confirmFn: () => {
+        metricsReporter.incrementCounter('confirm-disable-prompt')
+
         atom.config.set('fuzzy-finder.useRipGrep', false)
         atom.config.set('fuzzy-finder.scoringSystem', SCORING_SYSTEMS.ALTERNATE)
       },
-      cancelBtn: 'No, thanks'
+      cancelBtn: 'No, thanks',
+      cancelFn: () => {
+        metricsReporter.incrementCounter('cancel-disable-prompt')
+      }
     }
   )
 }
@@ -87,11 +101,13 @@ function isFastModeEnabled () {
   )
 }
 
-function renderExperimentPrompt () {
+function renderExperimentPrompt (metricsReporter) {
   if (isFastModeEnabled()) {
+    metricsReporter.incrementCounter('show-disable-prompt')
+
     return (
       $.span({className: 'experiment-prompt'}, [
-        $.a({onmousedown: disableExperimentalFuzzyFinder}, [
+        $.a({onmousedown: disableExperimentalFuzzyFinder.bind(null, metricsReporter)}, [
           $.span({className: ''}, 'Having issues with the fast mode?'),
           $.span({className: 'icon icon-rocket'}, '')
         ])
@@ -99,9 +115,11 @@ function renderExperimentPrompt () {
     )
   }
 
+  metricsReporter.incrementCounter('show-enable-prompt')
+
   return (
     $.span({className: 'experiment-prompt'}, [
-      $.a({onmousedown: enableExperimentalFuzzyFinder}, [
+      $.a({onmousedown: enableExperimentalFuzzyFinder.bind(null, metricsReporter)}, [
         shouldShowBadge() ? $.span({className: 'badge badge-info'}, 'NEW') : null,
         $.span({className: ''}, 'Try experimental fast mode?'),
         $.span({className: 'icon icon-microscope'}, '')

--- a/lib/experiment-prompt.js
+++ b/lib/experiment-prompt.js
@@ -2,6 +2,26 @@ const etch = require('etch')
 const $ = etch.dom
 const SCORING_SYSTEMS = require('./scoring-systems')
 
+/**
+ * For how long to show the "NEW" badge in the prompt since the first time
+ * it was seen (24h).
+ */
+const TimeToShowNewBadge = 24 * 60 * 10 * 1000
+const FirstTimeShownKey = 'fuzzy-finder:prompt-first-time-shown'
+
+function shouldShowBadge () {
+  const firstTimeShown = localStorage.getItem(FirstTimeShownKey)
+  const now = new Date().getTime()
+
+  if (!firstTimeShown) {
+    localStorage.setItem(FirstTimeShownKey, now)
+
+    return true
+  }
+
+  return now - firstTimeShown <= TimeToShowNewBadge
+}
+
 function enableExperimentalFuzzyFinder () {
   const notification = atom.notifications.addInfo(
     'The project you\'ve opened is quite large, which may cause performance issues on the quick open menu. Do you want to enable the new experimental fast mode for the quick open menu?',
@@ -35,7 +55,7 @@ function renderExperimentPrompt () {
   return (
     $.span({className: 'experiment-prompt'}, [
       $.a({onmousedown: enableExperimentalFuzzyFinder}, [
-        $.span({className: 'badge badge-info'}, 'NEW'),
+        shouldShowBadge() ? $.span({className: 'badge badge-info'}, 'NEW') : null,
         $.span({className: ''}, 'Try experimental fast mode?'),
         $.span({className: 'icon icon-microscope'}, '')
       ])

--- a/lib/experiment-prompt.js
+++ b/lib/experiment-prompt.js
@@ -109,7 +109,7 @@ function renderExperimentPrompt (metricsReporter) {
       $.span({className: 'experiment-prompt'}, [
         $.a({onmousedown: disableExperimentalFuzzyFinder.bind(null, metricsReporter)}, [
           $.span({className: 'icon icon-rocket'}, ''),
-          $.span({className: ''}, 'Using experimental fast mode. Opt out?'),
+          $.span({className: ''}, 'Using experimental fast mode. Opt out?')
         ])
       ])
     )

--- a/lib/experiment-prompt.js
+++ b/lib/experiment-prompt.js
@@ -1,0 +1,48 @@
+const etch = require('etch')
+const $ = etch.dom
+const SCORING_SYSTEMS = require('./scoring-systems')
+
+function enableExperimentalFuzzyFinder () {
+  const notification = atom.notifications.addInfo(
+    'The project you\'ve opened is quite large, which may cause performance issues on the quick open menu. Do you want to enable the new experimental fast mode for the quick open menu?',
+    {
+      detail: 'This mode can be disabled from the fuzzy finder settings later',
+      dismissable: true,
+      buttons: [
+        {
+          text: 'Enable experimental fast mode',
+          onDidClick: () => {
+            atom.config.set('fuzzy-finder.scoringSystem', SCORING_SYSTEMS.FAST)
+            atom.config.set('fuzzy-finder.useRipGrep', true)
+
+            notification.dismiss()
+          },
+          className: 'btn btn-info btn-primary'
+        },
+        {
+          text: 'No',
+          onDidClick: () => {
+            notification.dismiss()
+          }
+        }
+      ],
+      icon: 'rocket'
+    }
+  )
+}
+
+function renderExperimentPrompt () {
+  return (
+    $.span({className: 'experiment-prompt'}, [
+      $.a({onmousedown: enableExperimentalFuzzyFinder}, [
+        $.span({className: 'badge badge-info'}, 'NEW'),
+        $.span({className: ''}, 'Try experimental fast mode?'),
+        $.span({className: 'icon icon-microscope'}, '')
+      ])
+    ])
+  )
+}
+
+module.exports = {
+  renderExperimentPrompt
+}

--- a/lib/experiment-prompt.js
+++ b/lib/experiment-prompt.js
@@ -6,7 +6,7 @@ const SCORING_SYSTEMS = require('./scoring-systems')
  * For how long to show the "NEW" badge in the prompt since the first time
  * it was seen (24h).
  */
-const TimeToShowNewBadge = 24 * 60 * 10 * 1000
+const TimeToShowNewBadge = 24 * 60 * 60 * 1000
 const FirstTimeShownKey = 'fuzzy-finder:prompt-first-time-shown'
 
 function shouldShowBadge () {
@@ -76,7 +76,7 @@ function disableExperimentalFuzzyFinder (metricsReporter) {
   metricsReporter.incrementCounter('click-disable-prompt')
 
   showNotification(
-    'Do you want to enable the new experimental fast mode for the quick open menu?',
+    'Do you want to disable the new experimental fast mode for the quick open menu?',
     {
       detail: 'You can reenable it later from the fuzzy finder',
       confirmBtn: 'Disable experimental fast mode',

--- a/lib/experiment-prompt.js
+++ b/lib/experiment-prompt.js
@@ -3,11 +3,20 @@ const $ = etch.dom
 const SCORING_SYSTEMS = require('./scoring-systems')
 
 /**
+ * Minimum number of files in the project needed to show the fast mode prompt.
+ */
+const ThresholdForShowingPrompt = 10000
+
+/**
  * For how long to show the "NEW" badge in the prompt since the first time
  * it was seen (24h).
  */
 const TimeToShowNewBadgeInMilliseconds = 24 * 60 * 60 * 1000
 const FirstTimeShownKey = 'fuzzy-finder:prompt-first-time-shown'
+
+function shouldShowPrompt (numItems) {
+  return numItems > ThresholdForShowingPrompt
+}
 
 function shouldShowBadge () {
   const firstTimeShown = localStorage.getItem(FirstTimeShownKey)
@@ -131,5 +140,6 @@ function renderExperimentPrompt (metricsReporter) {
 }
 
 module.exports = {
-  renderExperimentPrompt
+  renderExperimentPrompt,
+  shouldShowPrompt
 }

--- a/lib/experiment-prompt.js
+++ b/lib/experiment-prompt.js
@@ -6,7 +6,7 @@ const SCORING_SYSTEMS = require('./scoring-systems')
  * For how long to show the "NEW" badge in the prompt since the first time
  * it was seen (24h).
  */
-const TimeToShowNewBadge = 24 * 60 * 60 * 1000
+const TimeToShowNewBadgeInMilliseconds = 24 * 60 * 60 * 1000
 const FirstTimeShownKey = 'fuzzy-finder:prompt-first-time-shown'
 
 function shouldShowBadge () {
@@ -19,7 +19,7 @@ function shouldShowBadge () {
     return true
   }
 
-  return now - firstTimeShown <= TimeToShowNewBadge
+  return now - firstTimeShown <= TimeToShowNewBadgeInMilliseconds
 }
 
 function showNotification (message, {detail, confirmBtn, cancelBtn, confirmFn, cancelFn}) {

--- a/lib/fuzzy-finder-view.js
+++ b/lib/fuzzy-finder-view.js
@@ -383,7 +383,9 @@ module.exports = class FuzzyFinderView {
           },
           {
             text: 'No',
-            onDidClick: () => {}
+            onDidClick: () => {
+              notification.dismiss()
+            }
           }
         ],
         icon: 'rocket'

--- a/lib/fuzzy-finder-view.js
+++ b/lib/fuzzy-finder-view.js
@@ -13,6 +13,11 @@ const {repositoryForPath} = require('./helpers')
 const getIconServices = require('./get-icon-services')
 
 /**
+ * Minimum number of files in the project needed to show the fast mode prompt.
+ */
+const ThresholdForShowingPrompt = 10000
+
+/**
  * These scoring systems should be synchronized with the enum values
  * on the scoringSystem config option defined in package.json
 **/
@@ -90,7 +95,10 @@ module.exports = class FuzzyFinderView {
           })
         }
 
-        if (this.selectListView.getQuery().length) {
+        if (
+          this.selectListView.getQuery().length ||
+          this.items.length < ThresholdForShowingPrompt
+        ) {
           return this.selectListView.update({
             infoMessage: null
           })
@@ -351,6 +359,13 @@ module.exports = class FuzzyFinderView {
     if (this.isQueryALineJump()) {
       return this.selectListView.update({
         items: [],
+        infoMessage: null,
+        loadingMessage: null,
+        loadingBadge: null
+      })
+    } else if (this.items.length < ThresholdForShowingPrompt) {
+      return this.selectListView.update({
+        items: this.items,
         infoMessage: null,
         loadingMessage: null,
         loadingBadge: null

--- a/lib/fuzzy-finder-view.js
+++ b/lib/fuzzy-finder-view.js
@@ -85,18 +85,7 @@ module.exports = class FuzzyFinderView {
           })
         }
 
-        if (
-          this.selectListView.getQuery().length ||
-          this.items.length < ThresholdForShowingPrompt
-        ) {
-          return this.selectListView.update({
-            infoMessage: null
-          })
-        } else {
-          return this.selectListView.update({
-            infoMessage: renderExperimentPrompt()
-          })
-        }
+        return this.updateExperimentPrompt()
       },
       elementForItem: ({filePath, label, ownerGitHubUsername}) => {
         const filterQuery = this.selectListView.getFilterQuery()
@@ -347,25 +336,35 @@ module.exports = class FuzzyFinderView {
     }
 
     if (this.isQueryALineJump()) {
-      return this.selectListView.update({
+      this.selectListView.update({
         items: [],
         infoMessage: null,
         loadingMessage: null,
         loadingBadge: null
       })
-    } else if (this.items.length < ThresholdForShowingPrompt) {
-      return this.selectListView.update({
+    } else {
+      this.selectListView.update({
         items: this.items,
         infoMessage: null,
         loadingMessage: null,
         loadingBadge: null
       })
+    }
+
+    return this.updateExperimentPrompt()
+  }
+
+  updateExperimentPrompt () {
+    if (
+      this.selectListView.getQuery().length ||
+      this.items.length < ThresholdForShowingPrompt
+    ) {
+      return this.selectListView.update({
+        infoMessage: null
+      })
     } else {
       return this.selectListView.update({
-        items: this.items,
-        infoMessage: renderExperimentPrompt(),
-        loadingMessage: null,
-        loadingBadge: null
+        infoMessage: renderExperimentPrompt()
       })
     }
   }

--- a/lib/fuzzy-finder-view.js
+++ b/lib/fuzzy-finder-view.js
@@ -1,10 +1,10 @@
 const {Point, CompositeDisposable} = require('atom')
-const etch = require('etch')
-const $ = etch.dom
+const {renderExperimentPrompt} = require('./experiment-prompt')
 const fs = require('fs-plus')
 const fuzzaldrin = require('fuzzaldrin')
 const fuzzaldrinPlus = require('fuzzaldrin-plus')
 const NativeFuzzy = require('@atom/fuzzy-native')
+const SCORING_SYSTEMS = require('./scoring-systems')
 
 const path = require('path')
 const SelectListView = require('atom-select-list')
@@ -16,16 +16,6 @@ const getIconServices = require('./get-icon-services')
  * Minimum number of files in the project needed to show the fast mode prompt.
  */
 const ThresholdForShowingPrompt = 10000
-
-/**
- * These scoring systems should be synchronized with the enum values
- * on the scoringSystem config option defined in package.json
-**/
-const SCORING_SYSTEMS = {
-  STANDARD: 'standard',
-  ALTERNATE: 'alternate',
-  FAST: 'fast'
-}
 
 const MAX_RESULTS = 10
 
@@ -104,7 +94,7 @@ module.exports = class FuzzyFinderView {
           })
         } else {
           return this.selectListView.update({
-            infoMessage: this.renderExperimentPrompt()
+            infoMessage: renderExperimentPrompt()
           })
         }
       },
@@ -373,54 +363,11 @@ module.exports = class FuzzyFinderView {
     } else {
       return this.selectListView.update({
         items: this.items,
-        infoMessage: this.renderExperimentPrompt(),
+        infoMessage: renderExperimentPrompt(),
         loadingMessage: null,
         loadingBadge: null
       })
     }
-  }
-
-  renderExperimentPrompt () {
-    return (
-      $.span({className: 'experiment-prompt'}, [
-        $.a({
-          onmousedown: this.enableExperimentalFuzzyFinder.bind(this)
-        }, [
-          $.span({className: 'badge badge-info'}, 'NEW'),
-          $.span({className: ''}, 'Try experimental fast mode?'),
-          $.span({className: 'icon icon-microscope'}, '')
-        ])
-      ])
-    )
-  }
-
-  enableExperimentalFuzzyFinder () {
-    const notification = atom.notifications.addInfo(
-      'The project you\'ve opened is quite large, which may cause performance issues on the quick open menu. Do you want to enable the new experimental fast mode for the quick open menu?',
-      {
-        detail: 'This mode can be disabled from the fuzzy finder settings later',
-        dismissable: true,
-        buttons: [
-          {
-            text: 'Enable experimental fast mode',
-            onDidClick: () => {
-              atom.config.set('fuzzy-finder.scoringSystem', SCORING_SYSTEMS.FAST)
-              atom.config.set('fuzzy-finder.useRipGrep', true)
-
-              notification.dismiss()
-            },
-            className: 'btn btn-info btn-primary'
-          },
-          {
-            text: 'No',
-            onDidClick: () => {
-              notification.dismiss()
-            }
-          }
-        ],
-        icon: 'rocket'
-      }
-    )
   }
 
   projectRelativePathsForFilePaths (filePaths) {

--- a/lib/fuzzy-finder-view.js
+++ b/lib/fuzzy-finder-view.js
@@ -1,5 +1,5 @@
 const {Point, CompositeDisposable} = require('atom')
-const {renderExperimentPrompt} = require('./experiment-prompt')
+const {renderExperimentPrompt, shouldShowPrompt} = require('./experiment-prompt')
 const fs = require('fs-plus')
 const fuzzaldrin = require('fuzzaldrin')
 const fuzzaldrinPlus = require('fuzzaldrin-plus')
@@ -11,11 +11,6 @@ const SelectListView = require('atom-select-list')
 
 const {repositoryForPath} = require('./helpers')
 const getIconServices = require('./get-icon-services')
-
-/**
- * Minimum number of files in the project needed to show the fast mode prompt.
- */
-const ThresholdForShowingPrompt = 10000
 
 const MAX_RESULTS = 10
 
@@ -359,7 +354,7 @@ module.exports = class FuzzyFinderView {
   updateExperimentPrompt () {
     if (
       this.selectListView.getQuery().length ||
-      this.items.length < ThresholdForShowingPrompt
+      !shouldShowPrompt(this.items.length)
     ) {
       return this.selectListView.update({
         infoMessage: null

--- a/lib/fuzzy-finder-view.js
+++ b/lib/fuzzy-finder-view.js
@@ -169,6 +169,8 @@ module.exports = class FuzzyFinderView {
         } else {
           this.selectListView.update({ filter: this.filterFn })
         }
+
+        this.updateExperimentPrompt()
       })
     )
   }

--- a/lib/fuzzy-finder-view.js
+++ b/lib/fuzzy-finder-view.js
@@ -365,7 +365,7 @@ module.exports = class FuzzyFinderView {
   }
 
   enableExperimentalFuzzyFinder () {
-    atom.notifications.addInfo(
+    const notification = atom.notifications.addInfo(
       'The project you\'ve opened is quite large, which may cause performance issues on the quick open menu. Do you want to enable the new experimental fast mode for the quick open menu?',
       {
         detail: 'This mode can be disabled from the fuzzy finder settings later',
@@ -373,7 +373,12 @@ module.exports = class FuzzyFinderView {
         buttons: [
           {
             text: 'Enable experimental fast mode',
-            onDidClick: () => {},
+            onDidClick: () => {
+              atom.config.set('fuzzy-finder.scoringSystem', SCORING_SYSTEMS.FAST)
+              atom.config.set('fuzzy-finder.useRipGrep', true)
+
+              notification.dismiss()
+            },
             className: 'btn btn-info btn-primary'
           },
           {

--- a/lib/fuzzy-finder-view.js
+++ b/lib/fuzzy-finder-view.js
@@ -91,14 +91,14 @@ module.exports = class FuzzyFinderView {
         }
 
         if (this.selectListView.getQuery().length) {
-         return this.selectListView.update({
-           infoMessage: null,
-         })
-       } else {
-         return this.selectListView.update({
-           infoMessage: this.renderExperimentPrompt(),
-         })
-       }
+          return this.selectListView.update({
+            infoMessage: null
+          })
+        } else {
+          return this.selectListView.update({
+            infoMessage: this.renderExperimentPrompt()
+          })
+        }
       },
       elementForItem: ({filePath, label, ownerGitHubUsername}) => {
         const filterQuery = this.selectListView.getFilterQuery()
@@ -353,7 +353,7 @@ module.exports = class FuzzyFinderView {
         items: [],
         infoMessage: null,
         loadingMessage: null,
-        loadingBadge: null,
+        loadingBadge: null
       })
     } else {
       return this.selectListView.update({

--- a/lib/fuzzy-finder-view.js
+++ b/lib/fuzzy-finder-view.js
@@ -89,6 +89,16 @@ module.exports = class FuzzyFinderView {
             errorMessage: null
           })
         }
+
+        if (this.selectListView.getQuery().length) {
+         return this.selectListView.update({
+           infoMessage: null,
+         })
+       } else {
+         return this.selectListView.update({
+           infoMessage: this.renderExperimentPrompt(),
+         })
+       }
       },
       elementForItem: ({filePath, label, ownerGitHubUsername}) => {
         const filterQuery = this.selectListView.getFilterQuery()
@@ -339,7 +349,12 @@ module.exports = class FuzzyFinderView {
     }
 
     if (this.isQueryALineJump()) {
-      return this.selectListView.update({items: [], loadingMessage: null, loadingBadge: null})
+      return this.selectListView.update({
+        items: [],
+        infoMessage: null,
+        loadingMessage: null,
+        loadingBadge: null,
+      })
     } else {
       return this.selectListView.update({
         items: this.items,

--- a/lib/fuzzy-finder-view.js
+++ b/lib/fuzzy-finder-view.js
@@ -1,4 +1,6 @@
 const {Point, CompositeDisposable} = require('atom')
+const etch = require('etch')
+const $ = etch.dom
 const fs = require('fs-plus')
 const fuzzaldrin = require('fuzzaldrin')
 const fuzzaldrinPlus = require('fuzzaldrin-plus')
@@ -339,8 +341,49 @@ module.exports = class FuzzyFinderView {
     if (this.isQueryALineJump()) {
       return this.selectListView.update({items: [], loadingMessage: null, loadingBadge: null})
     } else {
-      return this.selectListView.update({items: this.items, loadingMessage: null, loadingBadge: null})
+      return this.selectListView.update({
+        items: this.items,
+        infoMessage: this.renderExperimentPrompt(),
+        loadingMessage: null,
+        loadingBadge: null
+      })
     }
+  }
+
+  renderExperimentPrompt () {
+    return (
+      $.span({className: 'experiment-prompt'}, [
+        $.a({
+          onmousedown: this.enableExperimentalFuzzyFinder.bind(this)
+        }, [
+          $.span({className: 'badge badge-info'}, 'NEW'),
+          $.span({className: ''}, 'Try experimental fast mode?'),
+          $.span({className: 'icon icon-microscope'}, '')
+        ])
+      ])
+    )
+  }
+
+  enableExperimentalFuzzyFinder () {
+    atom.notifications.addInfo(
+      'The project you\'ve opened is quite large, which may cause performance issues on the quick open menu. Do you want to enable the new experimental fast mode for the quick open menu?',
+      {
+        detail: 'This mode can be disabled from the fuzzy finder settings later',
+        dismissable: true,
+        buttons: [
+          {
+            text: 'Enable experimental fast mode',
+            onDidClick: () => {},
+            className: 'btn btn-info btn-primary'
+          },
+          {
+            text: 'No',
+            onDidClick: () => {}
+          }
+        ],
+        icon: 'rocket'
+      }
+    )
   }
 
   projectRelativePathsForFilePaths (filePaths) {

--- a/lib/fuzzy-finder-view.js
+++ b/lib/fuzzy-finder-view.js
@@ -366,7 +366,7 @@ module.exports = class FuzzyFinderView {
       })
     } else {
       return this.selectListView.update({
-        infoMessage: renderExperimentPrompt()
+        infoMessage: renderExperimentPrompt(this.metricsReporter)
       })
     }
   }

--- a/lib/project-view.js
+++ b/lib/project-view.js
@@ -108,14 +108,14 @@ class ProjectView extends FuzzyFinderView {
       }
 
       if (this.paths) {
-        await this.selectListView.update({loadingMessage: 'Reindexing project\u2026'})
+        await this.selectListView.update({loadingMessage: 'Reindexing project\u2026', infoMessage: null})
       } else {
-        await this.selectListView.update({loadingMessage: 'Indexing project\u2026', loadingBadge: '0'})
+        await this.selectListView.update({loadingMessage: 'Indexing project\u2026', infoMessage: null, loadingBadge: '0'})
         if (task) {
           let pathsFound = 0
           task.on('load-paths:paths-found', (paths) => {
             pathsFound += paths.length
-            this.selectListView.update({loadingMessage: 'Indexing project\u2026', loadingBadge: humanize.intComma(pathsFound)})
+            this.selectListView.update({loadingMessage: 'Indexing project\u2026', infoMessage: null, loadingBadge: humanize.intComma(pathsFound)})
           })
         }
       }

--- a/lib/reporter-proxy.js
+++ b/lib/reporter-proxy.js
@@ -4,6 +4,7 @@ module.exports = class ReporterProxy {
   constructor () {
     this.reporter = null
     this.timingsQueue = []
+    this.countersQueue = []
 
     this.eventType = 'fuzzy-finder-v1'
 
@@ -13,9 +14,14 @@ module.exports = class ReporterProxy {
   setReporter (reporter) {
     this.reporter = reporter
     let timingsEvent
+    let counterName
 
     while ((timingsEvent = this.timingsQueue.shift())) {
       this.reporter.addTiming(this.eventType, timingsEvent[0], timingsEvent[1])
+    }
+
+    while ((counterName = this.countersQueue.shift())) {
+      this.reporter.incrementCounter(counterName)
     }
   }
 
@@ -43,6 +49,14 @@ module.exports = class ReporterProxy {
     }
 
     this._addTimingThrottled(duration, metadata)
+  }
+
+  incrementCounter (counterName) {
+    if (this.reporter) {
+      this.reporter.incrementCounter(counterName)
+    } else {
+      this.countersQueue.push(counterName)
+    }
   }
 
   _addTiming (duration, metadata) {

--- a/lib/scoring-systems.js
+++ b/lib/scoring-systems.js
@@ -1,0 +1,9 @@
+/**
+ * These scoring systems should be synchronized with the enum values
+ * on the scoringSystem config option defined in package.json
+**/
+module.exports = {
+  STANDARD: 'standard',
+  ALTERNATE: 'alternate',
+  FAST: 'fast'
+}

--- a/styles/fuzzy-finder.less
+++ b/styles/fuzzy-finder.less
@@ -25,3 +25,9 @@
     right: @component-padding;
   }
 }
+
+.fuzzy-finder .experiment-prompt {
+  span {
+    margin: 0 (@component-padding / 2);
+  }
+}

--- a/styles/fuzzy-finder.less
+++ b/styles/fuzzy-finder.less
@@ -26,6 +26,11 @@
   }
 }
 
-.fuzzy-finder .experiment-prompt .badge {
-  margin-right: (@component-padding / 2);
+.fuzzy-finder .experiment-prompt {
+  display: flex;
+  justify-content: flex-end;
+
+  .badge {
+    margin-right: (@component-padding / 2);
+  }
 }

--- a/styles/fuzzy-finder.less
+++ b/styles/fuzzy-finder.less
@@ -26,8 +26,6 @@
   }
 }
 
-.fuzzy-finder .experiment-prompt {
-  span {
-    margin: 0 (@component-padding / 2);
-  }
+.fuzzy-finder .experiment-prompt .badge {
+  margin-right: (@component-padding / 2);
 }


### PR DESCRIPTION
### Description of the Change

This PR adds a prompt to the fuzzy finder which will inform users about the "fast mode" and will allow them to enable it easily.

In order to get the major benefits, the prompt will only be shown when opening large projects, and users will be able to disable the setting via the same prompt later.

<img width="597" alt="Screen Shot 2019-04-03 at 19 54 49" src="https://user-images.githubusercontent.com/408035/55503283-a9ef9780-564e-11e9-8c68-eb29793c3e3e.png">

### Alternate Designs

More information in the associated task: https://github.com/atom/fuzzy-finder/issues/376

### Next steps

Things that need to be implemented still:

- [x] Add logic to show the prompt only for large projects.
- [x] Add logic to modify the user settings when clicking the notification.
- [x] Add logic to remove the "new" label after some time (or after the prompt has been shown a specific number of times).
- [x] Add the prompt that allow users to disable the setting once it's enabled.
  - [x] Add disable notification which allows to turn the setting off and show information to provide feedback.
  -  [x] Add logic to modify the user settings when clicking the notification.
- [x] Add metrics.
  - [x] Number of times the "enable prompt" is shown.
  - [x] Number of times people click on the "enable prompt".
  - [x] Number of times people enable the fast mode from the notification.
  - [x] Number of times the "disable prompt" is shown.
  - [x] Number of times people click on the "disable prompt".
  - [x] Number of times people disable the fast mode from the notification.
- [x] Improve codestyle.
- [x] Improve design.
- [x] Test the fuzzy-finder design updates in all UI themes that ship with Atom and also in the [top ~3 community UI themes](https://atom.io/themes/list?sort=downloads&direction=desc).
- [x] Improve prompt and notification copy.

### Verification steps

- [x] Verify prompt with the default Atom config.
  - [x] Check that no prompt is shown on small (< 10k files) projects.
  - [x] Check that the enable prompt is shown on large (> 10k files) projects.
  - [x] Check that the prompt is not shown at the same time than the following messages:
     - [x] Re-indexing project
     - [x] No results found.
  - [x] Check that the prompt automatically appears after the project is reindexed.
  - [x] Check that clicking the prompt shows a notification to enable fast mode.
     - [x] Clicking on the cancel button of the notification does not do anything.
     - [x] Clicking on the confirmation button of the notification changes the ripgrep and the scoring system config values of the fuzzy finder and shows a confirmation message.
- [x] Verify prompt when fast mode is enabled.
  - [x] Check that now the prompt is shown on any project size.
  - [x] Check that the message is different than the one to enable the prompt.
  - [x] Check that the prompt is not shown at the same time than the following messages:
     - [x] Re-indexing project
     - [x] No results found.
  - [x] Check that the prompt automatically appears after the project is reindexed.
  - [x] Check that clicking the prompt shows a notification to disable fast mode.
     - [x] Clicking on the cancel button of the notification does not do anything.
     - [x] Clicking on the confirmation button of the notification changes the ripgrep and the scoring system config values of the fuzzy finder and shows a confirmation message.
- [x] Test the fuzzy-finder design updates in all UI themes that ship with Atom and also in the [top ~3 community UI themes](https://atom.io/themes/list?sort=downloads&direction=desc).
- [x] Verify that each of the newly created metric counters are sent correctly.

### Applicable Issues

https://github.com/atom/fuzzy-finder/issues/376