### PR TITLE
Pass metricsReporter into GitStatusView to avoid null exception

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -103,7 +103,7 @@ module.exports = {
   createGitStatusView () {
     if (this.gitStatusView == null) {
       const GitStatusView = require('./git-status-view')
-      this.gitStatusView = new GitStatusView()
+      this.gitStatusView = new GitStatusView(metricsReporter)
     }
     return this.gitStatusView
   },


### PR DESCRIPTION
Closes #380

Since there were no tests introduced in #378, I've opted to just fix the bug and not add regression coverage.