### PR TITLE
Handle correctly similar results from multiple projects

### DIFF
--- a/lib/fuzzy-finder-view.js
+++ b/lib/fuzzy-finder-view.js
@@ -390,27 +390,32 @@ module.exports = class FuzzyFinderView {
     return {uri: filePath, filePath, label}
   }
 
-  getAbsolutePath (relativePath) {
-    const directories = atom.project.getDirectories()
+  parseResultsFromFuzzyNative (results) {
+    const absolutePaths = new Set()
 
-    if (directories.length === 1) {
-      return path.join(directories[0].getPath(), relativePath)
-    }
+    for (const {value: relativePath} of results) {
+      const directories = atom.project.getDirectories()
 
-    // Remove the first part of the relative path, since it contains the project
-    // directory name if there are many directories opened.
-    relativePath = path.join(...relativePath.split(path.sep).slice(1))
+      if (directories.length === 1) {
+        absolutePaths.add(path.join(directories[0].getPath(), relativePath))
+      } else {
+        // Remove the first part of the relative path, since it contains the project
+        // directory name if there are many directories opened.
+        const newRelativePath = path.join(...relativePath.split(path.sep).slice(1))
 
-    for (const directory of directories) {
-      const absolutePath = path.join(directory.getPath(), relativePath)
+        for (const directory of directories) {
+          const absolutePath = path.join(directory.getPath(), newRelativePath)
 
-      if (fs.existsSync(absolutePath)) {
-        return absolutePath
+          if (fs.existsSync(absolutePath)) {
+            absolutePaths.add(absolutePath)
+          }
+        }
       }
     }
 
-    // Best effort: just return the relative path.
-    return relativePath
+    return Array.from(absolutePaths).map(
+      absolutePath => this.convertPathToSelectViewObject(absolutePath)
+    )
   }
 
   filterFn (items, query) {
@@ -422,8 +427,8 @@ module.exports = class FuzzyFinderView {
     const startTime = performance.now()
 
     if (this.scoringSystem === SCORING_SYSTEMS.FAST) {
-      results = this.nativeFuzzy.match(query, {maxResults: MAX_RESULTS}).map(
-        result => this.convertPathToSelectViewObject(this.getAbsolutePath(result.value))
+      results = this.parseResultsFromFuzzyNative(
+        this.nativeFuzzy.match(query, {maxResults: MAX_RESULTS})
       )
     } else {
       results = fuzzaldrinPlus.filter(items, query, {key: 'label'})

--- a/lib/fuzzy-finder-view.js
+++ b/lib/fuzzy-finder-view.js
@@ -390,7 +390,7 @@ module.exports = class FuzzyFinderView {
     return {uri: filePath, filePath, label}
   }
 
-  parseResultsFromFuzzyNative (results) {
+  convertFuzzyNativeResultsToViews (results) {
     const absolutePaths = new Set()
 
     for (const {value: relativePath} of results) {
@@ -427,7 +427,7 @@ module.exports = class FuzzyFinderView {
     const startTime = performance.now()
 
     if (this.scoringSystem === SCORING_SYSTEMS.FAST) {
-      results = this.parseResultsFromFuzzyNative(
+      results = this.convertFuzzyNativeResultsToViews(
         this.nativeFuzzy.match(query, {maxResults: MAX_RESULTS})
       )
     } else {

--- a/spec/fuzzy-finder-spec.js
+++ b/spec/fuzzy-finder-spec.js
@@ -361,7 +361,7 @@ describe('FuzzyFinder', () => {
             expect(Array.from(projectView.element.querySelectorAll('li')).filter(a => a.textContent.includes('child-file.txt')).length).toBe(1)
           })
 
-          it('Return all the results if they have the same relative path across multiple root folders', async () => {
+          it('returns all the results if they have the same relative path across multiple root folders', async () => {
             fs.writeFileSync(path.join(rootDir1, 'whatever.js'), 'stuff')
             fs.writeFileSync(path.join(rootDir2, 'whatever.js'), 'stuff')
 
@@ -377,7 +377,7 @@ describe('FuzzyFinder', () => {
             ])
           })
 
-          it('Return all the results if they have the same relative path across multiple root folders with the same name', async () => {
+          it('returns all the results if they have the same relative path across multiple root folders with the same name', async () => {
             const ancestorDir = fs.realpathSync(temp.mkdirSync())
             const rootDir3 = path.join(ancestorDir, 'root-dir1')
             fs.mkdirSync(rootDir3)


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

This PR fixes https://github.com/atom/fuzzy-finder/issues/382 by adding any root that contains a filter result to the list of final results. 

### Alternate Designs

We could change `fuzzy-native` to accept an object that contains both the full path of the result (or an id) + the string to use for the matcher (as the standard fuzzy matcher does), but that would require sending a much bigger object to the native side which could slowdown thing (plus the change would be bigger and affect other repos).

### Benefits

Fixes https://github.com/atom/fuzzy-finder/issues/382

### Possible Drawbacks

None that I can think of.

### Applicable Issues

https://github.com/atom/fuzzy-finder/issues/382
