### PR TITLE
Eliminate synchronous I/O on main thread when displaying match results from fuzzy-native

### DIFF
--- a/lib/fuzzy-finder-view.js
+++ b/lib/fuzzy-finder-view.js
@@ -92,7 +92,7 @@ module.exports = class FuzzyFinderView {
             matches = fuzzaldrin.match(label, filterQuery)
             break
           case SCORING_SYSTEMS.FAST:
-            this.nativeFuzzyForResults.setCandidates([label])
+            this.nativeFuzzyForResults.setCandidates([0], [label])
             const items = this.nativeFuzzyForResults.match(
               filterQuery,
               {maxResults: 1, recordMatchIndexes: true}
@@ -152,12 +152,15 @@ module.exports = class FuzzyFinderView {
           this.selectListView.update({filter: null})
         } else if (this.scoringSystem === SCORING_SYSTEMS.FAST) {
           if (!this.nativeFuzzy) {
-            this.nativeFuzzy = new NativeFuzzy.Matcher(this.items.map(el => el.label))
+            this.nativeFuzzy = new NativeFuzzy.Matcher(
+              indexArray(this.items.length),
+              this.items.map(el => el.label)
+            )
 
             // We need a separate instance of the fuzzy finder to calculate the
             // matched paths only for the returned results. This speeds up considerably
             // the filtering of items.
-            this.nativeFuzzyForResults = new NativeFuzzy.Matcher([])
+            this.nativeFuzzyForResults = new NativeFuzzy.Matcher([], [])
           }
 
           this.selectListView.update({ filter: this.filterFn })
@@ -329,7 +332,10 @@ module.exports = class FuzzyFinderView {
 
     if (this.scoringSystem === SCORING_SYSTEMS.FAST) {
       // Beware: this operation is quite slow for large projects!
-      this.nativeFuzzy.setCandidates(this.items.map(item => item.label))
+      this.nativeFuzzy.setCandidates(
+        indexArray(this.items.length),
+        this.items.map(item => item.label)
+      )
     }
 
     if (this.isQueryALineJump()) {
@@ -390,34 +396,6 @@ module.exports = class FuzzyFinderView {
     return {uri: filePath, filePath, label}
   }
 
-  convertFuzzyNativeResultsToViews (results) {
-    const absolutePaths = new Set()
-
-    for (const {value: relativePath} of results) {
-      const directories = atom.project.getDirectories()
-
-      if (directories.length === 1) {
-        absolutePaths.add(path.join(directories[0].getPath(), relativePath))
-      } else {
-        // Remove the first part of the relative path, since it contains the project
-        // directory name if there are many directories opened.
-        const newRelativePath = path.join(...relativePath.split(path.sep).slice(1))
-
-        for (const directory of directories) {
-          const absolutePath = path.join(directory.getPath(), newRelativePath)
-
-          if (fs.existsSync(absolutePath)) {
-            absolutePaths.add(absolutePath)
-          }
-        }
-      }
-    }
-
-    return Array.from(absolutePaths).map(
-      absolutePath => this.convertPathToSelectViewObject(absolutePath)
-    )
-  }
-
   filterFn (items, query) {
     if (!query) {
       return items
@@ -427,9 +405,8 @@ module.exports = class FuzzyFinderView {
     const startTime = performance.now()
 
     if (this.scoringSystem === SCORING_SYSTEMS.FAST) {
-      results = this.convertFuzzyNativeResultsToViews(
-        this.nativeFuzzy.match(query, {maxResults: MAX_RESULTS})
-      )
+      results = this.nativeFuzzy.match(query, {maxResults: MAX_RESULTS})
+        .map(({id}) => this.items[id])
     } else {
       results = fuzzaldrinPlus.filter(items, query, {key: 'label'})
     }
@@ -479,6 +456,14 @@ function highlight (path, matches, offsetIndex) {
   // Remaining characters are plain text
   fragment.appendChild(document.createTextNode(path.substring(lastIndex)))
   return fragment
+}
+
+function indexArray(length) {
+  const array = []
+  for (let i = 0; i < length; i++) {
+    array[i] = i
+  }
+  return array
 }
 
 class FuzzyFinderItem {

--- a/lib/fuzzy-finder-view.js
+++ b/lib/fuzzy-finder-view.js
@@ -458,7 +458,7 @@ function highlight (path, matches, offsetIndex) {
   return fragment
 }
 
-function indexArray(length) {
+function indexArray (length) {
   const array = []
   for (let i = 0; i < length; i++) {
     array[i] = i

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,26 +5,18 @@
   "requires": true,
   "dependencies": {
     "@atom/fuzzy-native": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@atom/fuzzy-native/-/fuzzy-native-0.7.0.tgz",
-      "integrity": "sha512-FupfyfBTN12/WL6zJ/GXWWMCpFAItFPkK85vEF/96YY1utSvpk3eaLTIvrwO9afbR2nJnmPpjW6YsMcat4PqOw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@atom/fuzzy-native/-/fuzzy-native-1.0.1.tgz",
+      "integrity": "sha512-qqpUL9NpR7Ee04CNoHK8eOXx3ON4e2AbxMFA4v1Ch6lCb7//K9YsJKTmTNT9W49dF9snV+hdgF4TNYD1gY7Qpg==",
       "requires": {
         "nan": "^2.0.0",
-        "node-pre-gyp": "^0.6.30",
+        "node-pre-gyp": "^0.10.0",
         "semver": "^5.0.0"
       },
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
           "bundled": true
-        },
-        "ajv": {
-          "version": "4.11.8",
-          "bundled": true,
-          "requires": {
-            "co": "^4.6.0",
-            "json-stable-stringify": "^1.0.1"
-          }
         },
         "ansi-regex": {
           "version": "2.1.1",
@@ -42,53 +34,9 @@
             "readable-stream": "^2.0.6"
           }
         },
-        "asn1": {
-          "version": "0.2.4",
-          "bundled": true,
-          "requires": {
-            "safer-buffer": "~2.1.0"
-          }
-        },
-        "assert-plus": {
-          "version": "0.2.0",
-          "bundled": true
-        },
-        "asynckit": {
-          "version": "0.4.0",
-          "bundled": true
-        },
-        "aws-sign2": {
-          "version": "0.6.0",
-          "bundled": true
-        },
-        "aws4": {
-          "version": "1.8.0",
-          "bundled": true
-        },
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true
-        },
-        "bcrypt-pbkdf": {
-          "version": "1.0.2",
-          "bundled": true,
-          "requires": {
-            "tweetnacl": "^0.14.3"
-          }
-        },
-        "block-stream": {
-          "version": "0.0.9",
-          "bundled": true,
-          "requires": {
-            "inherits": "~2.0.0"
-          }
-        },
-        "boom": {
-          "version": "2.10.1",
-          "bundled": true,
-          "requires": {
-            "hoek": "2.x.x"
-          }
         },
         "brace-expansion": {
           "version": "1.1.11",
@@ -98,24 +46,13 @@
             "concat-map": "0.0.1"
           }
         },
-        "caseless": {
-          "version": "0.12.0",
-          "bundled": true
-        },
-        "co": {
-          "version": "4.6.0",
+        "chownr": {
+          "version": "1.1.1",
           "bundled": true
         },
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true
-        },
-        "combined-stream": {
-          "version": "1.0.7",
-          "bundled": true,
-          "requires": {
-            "delayed-stream": "~1.0.0"
-          }
         },
         "concat-map": {
           "version": "0.0.1",
@@ -129,26 +66,6 @@
           "version": "1.0.2",
           "bundled": true
         },
-        "cryptiles": {
-          "version": "2.0.5",
-          "bundled": true,
-          "requires": {
-            "boom": "2.x.x"
-          }
-        },
-        "dashdash": {
-          "version": "1.14.1",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "^1.0.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true
-            }
-          }
-        },
         "debug": {
           "version": "2.6.9",
           "bundled": true,
@@ -160,10 +77,6 @@
           "version": "0.6.0",
           "bundled": true
         },
-        "delayed-stream": {
-          "version": "1.0.0",
-          "bundled": true
-        },
         "delegates": {
           "version": "1.0.0",
           "bundled": true
@@ -172,57 +85,16 @@
           "version": "1.0.3",
           "bundled": true
         },
-        "ecc-jsbn": {
-          "version": "0.1.2",
+        "fs-minipass": {
+          "version": "1.2.5",
           "bundled": true,
           "requires": {
-            "jsbn": "~0.1.0",
-            "safer-buffer": "^2.1.0"
-          }
-        },
-        "extend": {
-          "version": "3.0.2",
-          "bundled": true
-        },
-        "extsprintf": {
-          "version": "1.3.0",
-          "bundled": true
-        },
-        "forever-agent": {
-          "version": "0.6.1",
-          "bundled": true
-        },
-        "form-data": {
-          "version": "2.1.4",
-          "bundled": true,
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.5",
-            "mime-types": "^2.1.12"
+            "minipass": "^2.2.1"
           }
         },
         "fs.realpath": {
           "version": "1.0.0",
           "bundled": true
-        },
-        "fstream": {
-          "version": "1.0.11",
-          "bundled": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "inherits": "~2.0.0",
-            "mkdirp": ">=0.5 0",
-            "rimraf": "2"
-          }
-        },
-        "fstream-ignore": {
-          "version": "1.0.5",
-          "bundled": true,
-          "requires": {
-            "fstream": "^1.0.0",
-            "inherits": "2",
-            "minimatch": "^3.0.0"
-          }
         },
         "gauge": {
           "version": "2.7.4",
@@ -238,19 +110,6 @@
             "wide-align": "^1.1.0"
           }
         },
-        "getpass": {
-          "version": "0.1.7",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "^1.0.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true
-            }
-          }
-        },
         "glob": {
           "version": "7.1.3",
           "bundled": true,
@@ -263,47 +122,22 @@
             "path-is-absolute": "^1.0.0"
           }
         },
-        "graceful-fs": {
-          "version": "4.1.15",
-          "bundled": true
-        },
-        "har-schema": {
-          "version": "1.0.5",
-          "bundled": true
-        },
-        "har-validator": {
-          "version": "4.2.1",
-          "bundled": true,
-          "requires": {
-            "ajv": "^4.9.1",
-            "har-schema": "^1.0.5"
-          }
-        },
         "has-unicode": {
           "version": "2.0.1",
           "bundled": true
         },
-        "hawk": {
-          "version": "3.1.3",
+        "iconv-lite": {
+          "version": "0.4.23",
           "bundled": true,
           "requires": {
-            "boom": "2.x.x",
-            "cryptiles": "2.x.x",
-            "hoek": "2.x.x",
-            "sntp": "1.x.x"
+            "safer-buffer": ">= 2.1.2 < 3"
           }
         },
-        "hoek": {
-          "version": "2.16.3",
-          "bundled": true
-        },
-        "http-signature": {
-          "version": "1.1.1",
+        "ignore-walk": {
+          "version": "3.0.1",
           "bundled": true,
           "requires": {
-            "assert-plus": "^0.2.0",
-            "jsprim": "^1.2.2",
-            "sshpk": "^1.7.0"
+            "minimatch": "^3.0.4"
           }
         },
         "inflight": {
@@ -329,67 +163,9 @@
             "number-is-nan": "^1.0.0"
           }
         },
-        "is-typedarray": {
-          "version": "1.0.0",
-          "bundled": true
-        },
         "isarray": {
           "version": "1.0.0",
           "bundled": true
-        },
-        "isstream": {
-          "version": "0.1.2",
-          "bundled": true
-        },
-        "jsbn": {
-          "version": "0.1.1",
-          "bundled": true
-        },
-        "json-schema": {
-          "version": "0.2.3",
-          "bundled": true
-        },
-        "json-stable-stringify": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "jsonify": "~0.0.0"
-          }
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "bundled": true
-        },
-        "jsonify": {
-          "version": "0.0.0",
-          "bundled": true
-        },
-        "jsprim": {
-          "version": "1.4.1",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "extsprintf": "1.3.0",
-            "json-schema": "0.2.3",
-            "verror": "1.10.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true
-            }
-          }
-        },
-        "mime-db": {
-          "version": "1.38.0",
-          "bundled": true
-        },
-        "mime-types": {
-          "version": "2.1.22",
-          "bundled": true,
-          "requires": {
-            "mime-db": "~1.38.0"
-          }
         },
         "minimatch": {
           "version": "3.0.4",
@@ -402,6 +178,24 @@
           "version": "0.0.8",
           "bundled": true
         },
+        "minipass": {
+          "version": "2.3.0",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "^5.1.1",
+            "yallist": "^3.0.0"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.1.1",
+              "bundled": true
+            },
+            "yallist": {
+              "version": "3.0.2",
+              "bundled": true
+            }
+          }
+        },
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
@@ -413,21 +207,29 @@
           "version": "2.0.0",
           "bundled": true
         },
+        "needle": {
+          "version": "2.2.1",
+          "bundled": true,
+          "requires": {
+            "debug": "^2.1.2",
+            "iconv-lite": "^0.4.4",
+            "sax": "^1.2.4"
+          }
+        },
         "node-pre-gyp": {
-          "version": "0.6.39",
+          "version": "0.10.3",
           "bundled": true,
           "requires": {
             "detect-libc": "^1.0.2",
-            "hawk": "3.1.3",
             "mkdirp": "^0.5.1",
+            "needle": "^2.2.1",
             "nopt": "^4.0.1",
+            "npm-packlist": "^1.1.6",
             "npmlog": "^4.0.2",
-            "rc": "^1.1.7",
-            "request": "2.81.0",
+            "rc": "^1.2.7",
             "rimraf": "^2.6.1",
             "semver": "^5.3.0",
-            "tar": "^2.2.1",
-            "tar-pack": "^3.4.0"
+            "tar": "^4"
           }
         },
         "nopt": {
@@ -436,6 +238,18 @@
           "requires": {
             "abbrev": "1",
             "osenv": "^0.1.4"
+          }
+        },
+        "npm-bundled": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "npm-packlist": {
+          "version": "1.1.10",
+          "bundled": true,
+          "requires": {
+            "ignore-walk": "^3.0.1",
+            "npm-bundled": "^1.0.1"
           }
         },
         "npmlog": {
@@ -450,10 +264,6 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
-        },
-        "oauth-sign": {
-          "version": "0.8.2",
           "bundled": true
         },
         "object-assign": {
@@ -487,20 +297,8 @@
           "version": "1.0.1",
           "bundled": true
         },
-        "performance-now": {
-          "version": "0.2.0",
-          "bundled": true
-        },
         "process-nextick-args": {
           "version": "2.0.0",
-          "bundled": true
-        },
-        "punycode": {
-          "version": "1.4.1",
-          "bundled": true
-        },
-        "qs": {
-          "version": "6.4.0",
           "bundled": true
         },
         "rc": {
@@ -532,34 +330,6 @@
             "util-deprecate": "~1.0.1"
           }
         },
-        "request": {
-          "version": "2.81.0",
-          "bundled": true,
-          "requires": {
-            "aws-sign2": "~0.6.0",
-            "aws4": "^1.2.1",
-            "caseless": "~0.12.0",
-            "combined-stream": "~1.0.5",
-            "extend": "~3.0.0",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.1.1",
-            "har-validator": "~4.2.1",
-            "hawk": "~3.1.3",
-            "http-signature": "~1.1.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.7",
-            "oauth-sign": "~0.8.1",
-            "performance-now": "^0.2.0",
-            "qs": "~6.4.0",
-            "safe-buffer": "^5.0.1",
-            "stringstream": "~0.0.4",
-            "tough-cookie": "~2.3.0",
-            "tunnel-agent": "^0.6.0",
-            "uuid": "^3.0.0"
-          }
-        },
         "rimraf": {
           "version": "2.6.3",
           "bundled": true,
@@ -575,6 +345,10 @@
           "version": "2.1.2",
           "bundled": true
         },
+        "sax": {
+          "version": "1.2.4",
+          "bundled": true
+        },
         "semver": {
           "version": "5.7.0",
           "bundled": true
@@ -586,34 +360,6 @@
         "signal-exit": {
           "version": "3.0.2",
           "bundled": true
-        },
-        "sntp": {
-          "version": "1.0.9",
-          "bundled": true,
-          "requires": {
-            "hoek": "2.x.x"
-          }
-        },
-        "sshpk": {
-          "version": "1.16.1",
-          "bundled": true,
-          "requires": {
-            "asn1": "~0.2.3",
-            "assert-plus": "^1.0.0",
-            "bcrypt-pbkdf": "^1.0.0",
-            "dashdash": "^1.12.0",
-            "ecc-jsbn": "~0.1.1",
-            "getpass": "^0.1.1",
-            "jsbn": "~0.1.0",
-            "safer-buffer": "^2.0.2",
-            "tweetnacl": "~0.14.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true
-            }
-          }
         },
         "string-width": {
           "version": "1.0.2",
@@ -631,10 +377,6 @@
             "safe-buffer": "~5.1.0"
           }
         },
-        "stringstream": {
-          "version": "0.0.6",
-          "bundled": true
-        },
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
@@ -647,72 +389,38 @@
           "bundled": true
         },
         "tar": {
-          "version": "2.2.1",
+          "version": "4.4.8",
           "bundled": true,
           "requires": {
-            "block-stream": "*",
-            "fstream": "^1.0.2",
-            "inherits": "2"
+            "chownr": "^1.1.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.3.4",
+            "minizlib": "^1.1.1",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.2"
+          },
+          "dependencies": {
+            "minipass": {
+              "version": "2.3.5",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.0"
+              }
+            },
+            "minizlib": {
+              "version": "1.2.1",
+              "bundled": true,
+              "requires": {
+                "minipass": "^2.2.1"
+              }
+            }
           }
-        },
-        "tar-pack": {
-          "version": "3.4.1",
-          "bundled": true,
-          "requires": {
-            "debug": "^2.2.0",
-            "fstream": "^1.0.10",
-            "fstream-ignore": "^1.0.5",
-            "once": "^1.3.3",
-            "readable-stream": "^2.1.4",
-            "rimraf": "^2.5.1",
-            "tar": "^2.2.1",
-            "uid-number": "^0.0.6"
-          }
-        },
-        "tough-cookie": {
-          "version": "2.3.4",
-          "bundled": true,
-          "requires": {
-            "punycode": "^1.4.1"
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "bundled": true,
-          "requires": {
-            "safe-buffer": "^5.0.1"
-          }
-        },
-        "tweetnacl": {
-          "version": "0.14.5",
-          "bundled": true
-        },
-        "uid-number": {
-          "version": "0.0.6",
-          "bundled": true
         },
         "util-deprecate": {
           "version": "1.0.2",
           "bundled": true
-        },
-        "uuid": {
-          "version": "3.3.2",
-          "bundled": true
-        },
-        "verror": {
-          "version": "1.10.0",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "^1.0.0",
-            "core-util-is": "1.0.2",
-            "extsprintf": "^1.2.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true
-            }
-          }
         },
         "wide-align": {
           "version": "1.1.3",
@@ -723,6 +431,10 @@
         },
         "wrappy": {
           "version": "1.0.2",
+          "bundled": true
+        },
+        "yallist": {
+          "version": "3.0.3",
           "bundled": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "fs-plus": "^3.0.0",
     "fuzzaldrin": "^2.0",
     "fuzzaldrin-plus": "^0.6.0",
-    "@atom/fuzzy-native": "^0.7.0",
+    "@atom/fuzzy-native": "^1.0.1",
     "humanize-plus": "~1.8.2",
     "minimatch": "~3.0.3",
     "temp": "~0.8.1",

--- a/spec/fuzzy-finder-spec.js
+++ b/spec/fuzzy-finder-spec.js
@@ -371,7 +371,10 @@ describe('FuzzyFinder', () => {
             await projectView.selectListView.refs.queryEditor.setText('whatever.js')
             await getOrScheduleUpdatePromise()
 
-            expect(parseResults(projectView.element)).toEqual([
+            // Sort results by path to ensure test is deterministic
+            const results = parseResults(projectView.element)
+              .sort((a, b) => a.description.localeCompare(b.description))
+            expect(results).toEqual([
               {label: 'whatever.js', description: path.join('root-dir1', 'whatever.js')},
               {label: 'whatever.js', description: path.join('root-dir2', 'whatever.js')}
             ])


### PR DESCRIPTION
🍐'd with @rafeca

### Description of the Change

Previously, limitations in the `fuzzy-native` API required us to call `fs.existsSync` on the main thread in order to map the relative paths in match results back into absolute paths in the presence of multiple project roots. This could block the main thread for an arbitrary amount of time and lead to performance degradation, so we decided to fix it.

The fix involved changing `fuzzy-native`'s API to associate each match candidate with an integer identifier. Currently, we're just assigning each item's id to its index in the items array. Now, when we get a match back from `fuzzy-native`, we can map it back to the original item that produced the candidate via the match's id. This removes the need for synchronous I/O to disambiguate the relative path.

### Alternate Designs

I'd love to replace fuzzy-native entirely, but that's out of scope right now.

### Benefits

* We no longer perform blocking I/O on the main thread, which could lead to performance problems.
* The code for processing match results from `fuzzy-native` is much simpler.

### Possible Drawbacks

* Our fork of `fuzzy-native` has diverged even further from the upstream repository, but my understanding is that it is mostly unmaintained anyway.

### Applicable Issues

#383
#382 
https://github.com/atom/fuzzy-native/pull/3