### PR TITLE
Make sure that cursor position is centered after navigating to a line

### DIFF
--- a/lib/fuzzy-finder-view.js
+++ b/lib/fuzzy-finder-view.js
@@ -268,11 +268,13 @@ module.exports = class FuzzyFinderView {
   moveToCaretPosition (caretPosition) {
     const editor = atom.workspace.getActiveTextEditor()
     if (editor && caretPosition.row >= 0) {
-      editor.scrollToBufferPosition(caretPosition, {center: true})
+      editor.unfoldBufferRow(caretPosition.row)
       editor.setCursorBufferPosition(caretPosition)
       if (caretPosition.column === -1) {
         editor.moveToFirstCharacterOfLine()
       }
+
+      editor.scrollToBufferPosition(caretPosition, {center: true})
     }
   }
 


### PR DESCRIPTION
### Description of the Change

In a similar way that https://github.com/atom/atom/pull/19272 fixed the scroll position after opening atom from the command line, this change does the same for the fuzzy finder. This way we have a consistent user experience for both scenarios.

The two main changes of this PR are:
* The selected line will get vertically centered in the editor.
* If the line is folder, it'll get unfolded.

**Before this change**

![before](https://user-images.githubusercontent.com/408035/57292642-7dea8a80-70c2-11e9-8c5f-de7ea9ddb52d.gif)

*With this change**

![after](https://user-images.githubusercontent.com/408035/57292894-61028700-70c3-11e9-97f2-b59e5d003233.gif)

### Alternate Designs

Do not do anything.

### Benefits

Consisten user experience when navigating to a line through the fuzzy finder.

### Possible Drawbacks

N/A

### Applicable Issues

https://github.com/atom/atom/issues/12253
