### PR TITLE
Adds getters for View classes

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -86,11 +86,40 @@ module.exports = {
     return paths
   },
 
+  get FuzzyFinderView () {
+    const FuzzyFinderView = require('./fuzzy-finder-view')
+    console.debug("GET FuzzyFinderView:", this, FuzzyFinderView)
+    delete this.FuzzyFinderView
+    this.FuzzyFinderView = FuzzyFinderView
+    return FuzzyFinderView
+  },
+  get ProjectView () {
+    const ProjectView = require('./project-view')
+    delete this.ProjectView
+    this.ProjectView = ProjectView
+    return ProjectView
+  },
+  get GitStatusView () {
+    const GitStatusView = require('./git-status-view')
+    delete this.GitStatusView
+    this.GitStatusView = GitStatusView
+    return GitStatusView
+  },
+  get BufferView () {
+    const BufferView = require('./buffer-view')
+    delete this.BufferView
+    this.BufferView = BufferView
+    return BufferView
+  },
+  get metricsReporter () {
+    return metricsReporter
+  },
+
   createProjectView () {
     this.stopLoadPathsTask()
 
     if (this.projectView == null) {
-      const ProjectView = require('./project-view')
+      const ProjectView = this.ProjectView
       this.projectView = new ProjectView(this.projectPaths, metricsReporter)
       this.projectPaths = null
       if (this.teletypeService) {
@@ -102,7 +131,7 @@ module.exports = {
 
   createGitStatusView () {
     if (this.gitStatusView == null) {
-      const GitStatusView = require('./git-status-view')
+      const GitStatusView = this.GitStatusView
       this.gitStatusView = new GitStatusView(metricsReporter)
     }
     return this.gitStatusView
@@ -110,7 +139,7 @@ module.exports = {
 
   createBufferView () {
     if (this.bufferView == null) {
-      const BufferView = require('./buffer-view')
+      const BufferView = this.BufferView
       this.bufferView = new BufferView(metricsReporter)
       if (this.teletypeService) {
         this.bufferView.setTeletypeService(this.teletypeService)

--- a/lib/main.js
+++ b/lib/main.js
@@ -88,7 +88,6 @@ module.exports = {
 
   get FuzzyFinderView () {
     const FuzzyFinderView = require('./fuzzy-finder-view')
-    console.debug("GET FuzzyFinderView:", this, FuzzyFinderView)
     delete this.FuzzyFinderView
     this.FuzzyFinderView = FuzzyFinderView
     return FuzzyFinderView


### PR DESCRIPTION
### Description of the Change

This adds 5 get functions for access to the 4 view classes and the metricsReporter so that other plugins can have easier access to construct their own instances of the 4 view classes.

### Alternate Designs

Some alternate options were covered in #390 

### Benefits

This doesn't change the existing functionality, and still maintains the lazy-load `requires()` style used in the `createX()` functions.

### Possible Drawbacks

I would think we'd want to expose the metricsReporter here, but if not I can instead add checks in the other view classes to special-case the metricsReporter being undefined.

### Applicable Issues

This is one of the ideas from #390 
