### PR TITLE
Show fast mode prompt on any project size

### DIFF
--- a/lib/experiment-prompt.js
+++ b/lib/experiment-prompt.js
@@ -3,11 +3,6 @@ const $ = etch.dom
 const SCORING_SYSTEMS = require('./scoring-systems')
 
 /**
- * Minimum number of files in the project needed to show the fast mode prompt.
- */
-const ThresholdForShowingPrompt = 10000
-
-/**
  * For how long to show the "NEW" badge in the prompt since the first time
  * it was seen (24h).
  */
@@ -20,7 +15,7 @@ function shouldShowPrompt (numItems) {
     return false
   }
 
-  return isFastModeEnabled() || numItems > ThresholdForShowingPrompt
+  return true
 }
 
 function shouldShowBadge () {

--- a/spec/buffer-view-spec.js
+++ b/spec/buffer-view-spec.js
@@ -5,7 +5,7 @@ const BufferView = require('../lib/buffer-view')
 
 describe('BufferView', () => {
   it('shows the avatar for editors that are remote', async () => {
-    const bufferView = new BufferView()
+    const bufferView = new BufferView({incrementCounter: () => {}})
 
     const localEditor1 = await atom.workspace.open(path.join(temp.path(), 'a'))
     const localEditor2 = await atom.workspace.open(path.join(temp.path(), 'b'))


### PR DESCRIPTION
This PR is a follow-up of https://github.com/atom/fuzzy-finder/pull/378 to get more people opting in to the fast mode.

## Context

Now that the fuzzy finder fast mode has been out for a couple of weeks in Atom v1.37 without any major issues, I’d like to open the gates a bit more to the feature to get more feedback from it before making it the default one.

The current plan is the following:

* **Atom v1.37:** Show prompt to enable it on large projects. (done)
* **Atom v1.38:** Show prompt to enable it on any project.
* **Atom v1.39:** Remove prompt and enable it by default.

Doing this will give us much more signal about the fast mode on Atom v1.38 before enabling it by default (since currently we only have ~0.5% of users with `ripgrep` enabled).

**Note**: Due to our release cadence, I'll need to cherry-pick the new version of the `fuzzy-finder` package on the `release-1.38` branch, but that should be fine.
