### PR TITLE
Fix excluding VCS ignored paths based on the flag in core settings when ripgrep is enabled

### DIFF
--- a/lib/load-paths-handler.js
+++ b/lib/load-paths-handler.js
@@ -23,6 +23,7 @@ const emittedPaths = new Set()
 class PathLoader {
   constructor (rootPath, ignoreVcsIgnores, traverseSymlinkDirectories, ignoredNames, useRipGrep) {
     this.rootPath = rootPath
+    this.ignoreVcsIgnores = ignoreVcsIgnores
     this.traverseSymlinkDirectories = traverseSymlinkDirectories
     this.ignoredNames = ignoredNames
     this.useRipGrep = useRipGrep
@@ -55,7 +56,7 @@ class PathLoader {
     return new Promise((resolve) => {
       const args = ['--files', '--hidden', '--sort', 'path']
 
-      if (this.ignoreVcsIgnores) {
+      if (!this.ignoreVcsIgnores) {
         args.push('--no-ignore')
       }
 

--- a/spec/fuzzy-finder-spec.js
+++ b/spec/fuzzy-finder-spec.js
@@ -1657,6 +1657,28 @@ describe('FuzzyFinder', () => {
           })
         })
 
+        describe('when core.excludeVcsIgnoredPaths is set to false', () => {
+          beforeEach(() => atom.config.set('core.excludeVcsIgnoredPaths', false))
+
+          describe("when the project's path is the repository's working directory", () => {
+            beforeEach(() => {
+              const ignoreFile = path.join(projectPath, '.gitignore')
+              fs.writeFileSync(ignoreFile, 'ignored.txt')
+
+              const ignoredFile = path.join(projectPath, 'ignored.txt')
+              fs.writeFileSync(ignoredFile, 'ignored text')
+            })
+
+            it("doesn't exclude paths that are git ignored", async () => {
+              await projectView.toggle()
+
+              await waitForPathsToDisplay(projectView)
+
+              expect(Array.from(projectView.element.querySelectorAll('li')).find(a => a.textContent.includes('ignored.txt'))).toBeDefined()
+            })
+          })
+        })
+
         describe('logging of metrics events', () => {
           let disposable
 


### PR DESCRIPTION
### Description of the Change

This fixes a bug when experimental fast mode that uses ripgrep is enabled. Since excluding VCS ignored paths is the default behavior of ripgrep, option to not ignore them was not being passed when needed.

### Alternate Designs

N/A

### Benefits

Excluding VCS ignored paths from fuzzy search will work a bit more consistently when using ripgrep.

### Possible Drawbacks

N/A

### Applicable Issues

N/A
