### PR TITLE
Avoid timeouts when listening on a socket in tests

### DIFF
--- a/spec/fuzzy-finder-spec.js
+++ b/spec/fuzzy-finder-spec.js
@@ -331,13 +331,15 @@ describe('FuzzyFinder', () => {
           describe('socket files on #darwin or #linux', () => {
             let socketServer, socketPath
 
-            beforeEach(() => {
+            beforeEach(() => new Promise((resolve, reject) => {
               socketServer = net.createServer(() => {})
               socketPath = path.join(rootDir1, 'some.sock')
-              waitsFor(done => socketServer.listen(socketPath, done))
-            })
+              socketServer.on('listening', resolve)
+              socketServer.on('error', reject)
+              socketServer.listen(socketPath)
+            }))
 
-            afterEach(() => socketServer.close())
+            afterEach(() => new Promise(resolve => socketServer.close(resolve)))
 
             it('does not interfere with ability to load files', async () => {
               await projectView.toggle()


### PR DESCRIPTION
This is an attempt to fix #386.

I worry that in cases where we are timing out, the attempt to listen might actually be producing an error, and we are simply dropping this error on the floor. If that is what's happening, we should now surface the error by rejecting the promise returned by the `beforeEach` block instead of just timing out in a `waitsFor` function.

I'm also waiting for the server to fully close in the `afterEach` block, just to be sure we stop listening before attempting to listen again. This seems unlikely, but it's more correct to wait for this anyway.