### PR TITLE
Ignore VCS directories even when they are not in ignoreNames

### DIFF
--- a/lib/load-paths-handler.js
+++ b/lib/load-paths-handler.js
@@ -68,6 +68,11 @@ class PathLoader {
         args.push('-g', '!' + ignoredName.pattern)
       }
 
+      if (this.ignoreVcsIgnores) {
+        if (!args.includes('!.git')) args.push('-g', '!.git')
+        if (!args.includes('!.hg')) args.push('-g', '!.hg')
+      }
+
       let output = ''
       const result = childProcess.spawn(realRgPath, args, {cwd: this.rootPath})
 

--- a/spec/fuzzy-finder-spec.js
+++ b/spec/fuzzy-finder-spec.js
@@ -1670,6 +1670,21 @@ describe('FuzzyFinder', () => {
               expect(Array.from(projectView.element.querySelectorAll('li')).find(a => a.textContent.includes('file.txt'))).toBeDefined()
             })
           })
+
+          describe('when core.ignoredNames does not have .git in its glob patterns', () => {
+            beforeEach(() => {
+              atom.config.set('core.ignoredNames', [])
+            })
+
+            it('still ignores .git directory', async () => {
+              await projectView.toggle()
+
+              await waitForPathsToDisplay(projectView)
+
+              expect(Array.from(projectView.element.querySelectorAll('li')).find(a =>
+                a.textContent.includes('HEAD'))).not.toBeDefined()
+            })
+          })
         })
 
         describe('when core.excludeVcsIgnoredPaths is set to false', () => {


### PR DESCRIPTION
Hi, this is my very first PR for Atom's core system ! 😁 

### Rationale

If an user's `core.ignoredNames` is modified so that it doesn't include `.git` or `.hg` (they are included by default) but still `core.excludeVcsIgnoredPaths` is `true`, then the new `fast` mode using `ripgrep` will show files in those directories (like `HEAD`, `COMMIT_EDITMSG` and so on).

Because those files are usually regarded as _VCS-ignored_ files and more over, the previous `alternative` mode does exclude those files when `core.excludeVcsIgnoredPaths` is `true`, I believe these files are better to be ignored in `fast` mode as well.

Please refer to https://github.com/atom/fuzzy-finder/issues/379#issuecomment-502635850 for more detail.

### Description of the Change

Only 5 line changes: Add `ripgrep` arguments to exclude those files when `core.excludeVcsIgnoredPaths` is `true`.

### Possible Drawbacks

To include those files, an user need to disable both `core.ignoredNames ` and `core.excludeVcsIgnoredPaths`, and it might be confusing ?
