### PR TITLE
Remove uneeded assertion in test

### DIFF
--- a/spec/fuzzy-finder-spec.js
+++ b/spec/fuzzy-finder-spec.js
@@ -166,10 +166,8 @@ describe('FuzzyFinder', () => {
 
           it('shows all files for the current project and selects the first', async () => {
             jasmine.attachToDOM(workspaceElement)
-
             await projectView.toggle()
 
-            expect(projectView.element.querySelector('.loading').textContent.length).toBeGreaterThan(0)
             await waitForPathsToDisplay(projectView)
 
             eachFilePath([rootDir1, rootDir2], (filePath) => {


### PR DESCRIPTION
This PR removes an assertion that's not actually needed in one of the `fuzzy-finder` specs. This assertion sometimes returns false (maybe because the crawler finishes too quickly) and was causing some failures.

This fixes https://github.com/atom/atom/issues/19581