### PR TITLE
Make fast mode the default mode and remove prompt

### DIFF
--- a/lib/experiment-prompt.js
+++ b/lib/experiment-prompt.js
@@ -10,12 +10,7 @@ const TimeToShowNewBadgeInMilliseconds = 24 * 60 * 60 * 1000
 const FirstTimeShownKey = 'fuzzy-finder:prompt-first-time-shown'
 
 function shouldShowPrompt (numItems) {
-  // The nucleus-dark-ui does not display the prompt correctly.
-  if (atom.themes.getActiveThemeNames().includes('nucleus-dark-ui')) {
-    return false
-  }
-
-  return true
+  return false
 }
 
 function shouldShowBadge () {

--- a/package.json
+++ b/package.json
@@ -80,8 +80,8 @@
     },
     "scoringSystem": {
       "type": "string",
-      "default": "alternate",
-      "description": "Scoring system to use. \"standard\" is the system used by other modals in Atom. \"alternate\" is an improved scoring system. \"fast\" is a much faster system, specially suitable for large projects. Default: \"alternate\"",
+      "default": "fast",
+      "description": "Scoring system to use. \"standard\" is the system used by other modals in Atom. \"alternate\" is an improved scoring system. \"fast\" is a much faster system, specially suitable for large projects. Default: \"fast\"",
       "enum": [
         "standard",
         "alternate",
@@ -90,8 +90,8 @@
     },
     "useRipGrep": {
       "type": "boolean",
-      "default": false,
-      "description": "Use the experimental `ripgrep` crawler. This will substantially speed up the indexing process on large projects."
+      "default": true,
+      "description": "Use the substantially faster `ripgrep` crawler."
     },
     "prefillFromSelection": {
       "type": "boolean",


### PR DESCRIPTION
Looks like we haven't got any major negative feedback during the opt-in period of the fast mode (more info [here](https://github.com/atom/fuzzy-finder/issues/379)), and the performance results are extremely positive from people opting in: **between 5X and 15X faster** depending on the project size:

<img width="1667" alt="Screenshot 2019-06-26 at 11 02 37" src="https://user-images.githubusercontent.com/408035/60166842-2636e880-9802-11e9-9631-7c02a84be911.png">

Based on that, we've decided to make the fast mode the default mode on fuzzy finder and remove the opt-in prompt. We're going to leave the config options to allow user to revert to the old behaviour for a while, just to get some time for some potential obscure edge cases to pop out.

I'm planning to release a new version of the fuzzy finder once this PR gets merged and cherry pick the new version into the Atom v1.39 release