### PR TITLE
⬆️ @atom/fuzzy-native@1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@atom/fuzzy-native": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@atom/fuzzy-native/-/fuzzy-native-1.0.3.tgz",
-      "integrity": "sha512-bpFKY270m+1JVZ5xEn1RIFo44ZwIYww0o/MZnev/SyMXZSuQEcJcgXbvz8mBAOK9Tpce4iDgRWcBLuBOoMbJSw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@atom/fuzzy-native/-/fuzzy-native-1.1.0.tgz",
+      "integrity": "sha512-S+dZtzAtpMB6m5xEJ6aSp33JX2s539KCGBWn0oLHFX2vsnHtqFeWIKFspFuUZCHsmp+2DwRJuWTZhgc/zA+6ow==",
       "requires": {
         "nan": "^2.0.0"
       }
@@ -748,7 +748,7 @@
       "dependencies": {
         "async": {
           "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
         }
       }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "fs-plus": "^3.0.0",
     "fuzzaldrin": "^2.0",
     "fuzzaldrin-plus": "^0.6.0",
-    "@atom/fuzzy-native": "^1.0.3",
+    "@atom/fuzzy-native": "^1.1.0",
     "humanize-plus": "~1.8.2",
     "minimatch": "~3.0.3",
     "temp": "~0.8.1",


### PR DESCRIPTION
This new version includes support to matching directory separators using `_` or `\\` ([more info](https://github.com/atom/fuzzy-native/pull/6)).

----

*List of changes between `fuzzy-native@1.0.3` and `fuzzy-native@1.1.0`: https://github.com/atom/fuzzy-native/compare/v1.0.3...v1.1.0*