### PR TITLE
Consume STDERR from ripgrep to allow indexing process to complete

### DIFF
--- a/lib/load-paths-handler.js
+++ b/lib/load-paths-handler.js
@@ -84,6 +84,9 @@ class PathLoader {
           this.pathLoaded(path.join(this.rootPath, file))
         }
       })
+      result.stderr.on('data', () => {
+        // intentionally ignoring errors for now
+      })
       result.on('close', () => {
         this.flushPaths()
         resolve()

--- a/spec/fuzzy-finder-spec.js
+++ b/spec/fuzzy-finder-spec.js
@@ -617,7 +617,7 @@ describe('FuzzyFinder', () => {
 
               expect(Array.from(bufferView.element.querySelectorAll('li > div.file')).map(e => e.textContent)).toEqual(['sample.js'])
             })
-        )
+          )
         })
 
         describe('when a path selection is confirmed', () => {
@@ -1772,6 +1772,28 @@ describe('FuzzyFinder', () => {
               expect(reporterStub.addTiming.getCalls().length).toBe(1)
             })
           }
+        })
+      })
+
+      describe('error handling', () => {
+        beforeEach(() => {
+          const junkDirPath = fs.realpathSync(temp.mkdirSync('junk-1'))
+          const brokenFilePath = path.join(junkDirPath, 'delete.txt')
+          fs.writeFileSync(brokenFilePath, 'delete-me')
+
+          for (let i = 0; i < 1000; i++) {
+            fs.symlinkSync(brokenFilePath, atom.project.getDirectories()[0].resolve('broken-symlink-' + i))
+          }
+
+          fs.unlinkSync(brokenFilePath)
+        })
+
+        it('copes with a lot of errors during indexing', async () => {
+          await projectView.toggle()
+
+          await waitForPathsToDisplay(projectView)
+
+          expect(projectView.element.querySelector('.loading')).not.toBeVisible()
         })
       })
     })


### PR DESCRIPTION
### Description of the Change
When indexing a project with a lot of broken symbolic links, the indexing process never completes. This is because the `ripgrep` process has written more data to its error output (STDERR) than the calling process has buffer to receive; until this buffer is cleared, the process will not terminate. The solution to this is to process the data on the receiving side.

This pull request adds a simple no-op handler for anything sent back on STDERR from `ripgrep`.

### Alternate Designs
I considered logging the error output from `ripgrep`. This produced a lot of noise when running the test-suite and is unlikely to be of use for anyone in the real world. Logging the error messages returned from `ripgrep` is a trivial change.

### Benefits
Indexing process always completes.

### Possible Drawbacks
Diagnosing some issues may be difficult due to the lack of logging, however before this change any messages sent to STDERR were already being lost.

### Applicable Issues
No obviously related open issues in this repository at time of opening this pull request. Lots of seemly-related external results when searching for this problem on the web.