### PR TITLE
⬆️@atom/fuzzy-native@1.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@atom/fuzzy-native": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@atom/fuzzy-native/-/fuzzy-native-1.1.0.tgz",
-      "integrity": "sha512-S+dZtzAtpMB6m5xEJ6aSp33JX2s539KCGBWn0oLHFX2vsnHtqFeWIKFspFuUZCHsmp+2DwRJuWTZhgc/zA+6ow==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@atom/fuzzy-native/-/fuzzy-native-1.1.1.tgz",
+      "integrity": "sha512-lsX1FNkrnLiYEqcEAcBb7TahgSOQwKAZ+pfZEIo3iwGcg/3qbtsrSddw16xFSNjHtvjiCqCpwjoPqC8MPQkj3A==",
       "requires": {
         "nan": "^2.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "fs-plus": "^3.0.0",
     "fuzzaldrin": "^2.0",
     "fuzzaldrin-plus": "^0.6.0",
-    "@atom/fuzzy-native": "^1.1.0",
+    "@atom/fuzzy-native": "^1.1.1",
     "humanize-plus": "~1.8.2",
     "minimatch": "~3.0.3",
     "temp": "~0.8.1",


### PR DESCRIPTION
removes the `-static-libstdc++` ld flag from binding.gyp and allows the package to dynamically bind to libstdc++ ([more info](https://github.com/atom/fuzzy-native/pull/7)).

----

*List of changes between `fuzzy-native@1.1.0` and `fuzzy-native@1.1.1`: https://github.com/atom/fuzzy-native/compare/v1.1.0...v1.1.1*